### PR TITLE
fix(docs): correct installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository serves as a marketplace for Claude Code plugins developed by Sig
 ## Installation
 
 ```bash
-/plugin add signalcompose/claude-tools
+/plugin marketplace add signalcompose/claude-tools
 ```
 
 ## Quick Start

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -47,5 +47,5 @@ claude-toolsはClaude Codeプラグインを配布するためのマーケット
 ## インストール方法
 
 ```bash
-/plugin add signalcompose/claude-tools
+/plugin marketplace add signalcompose/claude-tools
 ```


### PR DESCRIPTION
## Summary

インストールコマンドを正しいものに修正

## Problem

誤ったコマンド: `/plugin add signalcompose/claude-tools`
正しいコマンド: `/plugin marketplace add signalcompose/claude-tools`

## Changes

- README.md: インストールコマンドを修正
- docs/specifications.md: インストールコマンドを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)