### PR TITLE
fix(code): rename plugin from code-review to code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
       "homepage": "https://github.com/signalcompose/claude-tools/tree/main/plugins/chezmoi"
     },
     {
-      "name": "code-review",
+      "name": "code",
       "description": "Code review workflow integration for git commits",
       "source": "./plugins/code-review",
       "category": "developer-tools",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository serves as a marketplace for Claude Code plugins developed by Sig
 | [CVI](./plugins/cvi) | Claude Voice Integration - Voice notifications for Claude Code on macOS | Available |
 | [YPM](./plugins/ypm) | Your Project Manager - Project management for Claude Code | Available |
 | [chezmoi](./plugins/chezmoi) | Dotfiles management integration using chezmoi | Available |
-| [code-review](./plugins/code-review) | Code review workflow integration for git commits | Available |
+| [code](./plugins/code-review) | Code review workflow integration for git commits | Available |
 
 ## Installation
 

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "code-review",
+  "name": "code",
   "version": "1.0.0",
   "description": "Code review workflow integration for git commits",
   "author": {


### PR DESCRIPTION
## Summary
- プラグイン名を `code-review` から `code` に変更
- これにより `/code:review-commit`, `/code:trufflehog-scan` の形式になる

## Changes
- plugins/code-review/.claude-plugin/plugin.json: name を "code" に
- .claude-plugin/marketplace.json: name を "code" に
- README.md: 表記更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)