### PR TITLE
fix(code): correct hooks.json format

### DIFF
--- a/plugins/code-review/hooks/hooks.json
+++ b/plugins/code-review/hooks/hooks.json
@@ -1,13 +1,15 @@
 {
-  "hooks": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-code-review.sh"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-code-review.sh"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- hooks.json のフォーマットを修正
- `"hooks"` は配列ではなくイベント名をキーとするオブジェクトが必要

## Error Fixed
```
Failed to load hooks from hooks.json:
Invalid input: expected record, received array
```

## Reference
- [Claude Code Hooks](https://code.claude.com/docs/en/hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)