### PR TITLE
fix(code): add name field to skill frontmatter

### DIFF
--- a/plugins/code-review/skills/review-commit/content.md
+++ b/plugins/code-review/skills/review-commit/content.md
@@ -1,4 +1,5 @@
 ---
+name: review-commit
 description: "Run code review and approve for commit (integrates with check-code-review.sh hook)"
 ---
 


### PR DESCRIPTION
## Summary
- スキルのフロントマターに必須の `name` フィールドを追加

## Problem
`/code:review-commit` スキルが認識されない

## Cause
スキルのフロントマターに `name` フィールドがなかった。
Claude Code はスキルを認識するために `name` と `description` の両方が必要。

## Reference
- [Claude Code Skills](https://code.claude.com/docs/en/skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)