### PR TITLE
feat(plugins): add utils plugin with clear-plugin-cache command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,6 +34,13 @@
       "source": "./plugins/code-review",
       "category": "developer-tools",
       "homepage": "https://github.com/signalcompose/claude-tools/tree/main/plugins/code-review"
+    },
+    {
+      "name": "utils",
+      "description": "Utility commands for Claude Code plugin management (cache clearing, etc.)",
+      "source": "./plugins/utils",
+      "category": "developer-tools",
+      "homepage": "https://github.com/signalcompose/claude-tools/tree/main/plugins/utils"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository serves as a marketplace for Claude Code plugins developed by Sig
 | [YPM](./plugins/ypm) | Your Project Manager - Project management for Claude Code | Available |
 | [chezmoi](./plugins/chezmoi) | Dotfiles management integration using chezmoi | Available |
 | [code](./plugins/code-review) | Code review workflow integration for git commits | Available |
+| [utils](./plugins/utils) | Utility commands for plugin management (cache clearing, etc.) | Available |
 
 ## Installation
 
@@ -34,6 +35,7 @@ Or use CLI commands:
 /plugin install ypm@claude-tools
 /plugin install chezmoi@claude-tools
 /plugin install code@claude-tools
+/plugin install utils@claude-tools
 ```
 
 ### 3. Update Marketplace
@@ -66,7 +68,7 @@ Or use CLI commands:
 1. Add the marketplace: `/plugin marketplace add signalcompose/claude-tools`
 2. Browse plugins: `/plugin` → Discover tab
 3. Install desired plugins
-4. Use plugin commands (e.g., `/cvi:status`, `/ypm:update`, `/chezmoi:check`, `/code:review-commit`)
+4. Use plugin commands (e.g., `/cvi:status`, `/ypm:update`, `/chezmoi:check`, `/code:review-commit`, `/utils:clear-plugin-cache`)
 5. See individual plugin documentation for detailed usage
 
 ## Documentation

--- a/plugins/utils/.claude-plugin/plugin.json
+++ b/plugins/utils/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "utils",
+  "version": "1.0.0",
+  "description": "Utility commands for Claude Code plugin management",
+  "author": {
+    "name": "SignalCompose"
+  },
+  "repository": "https://github.com/signalcompose/claude-tools",
+  "license": "MIT",
+  "keywords": ["utility", "cache", "plugin-management"]
+}

--- a/plugins/utils/README.md
+++ b/plugins/utils/README.md
@@ -1,0 +1,73 @@
+# utils
+
+Utility commands for Claude Code plugin management.
+
+## Overview
+
+This plugin provides utility commands to help manage Claude Code plugins. Currently, it includes a workaround for the plugin cache invalidation bug.
+
+## Available Commands
+
+### `/utils:clear-plugin-cache`
+
+Clear plugin cache to fix stale version issues after running `/plugin update`.
+
+## Known Issues (Claude Code)
+
+This plugin exists as a workaround for known Claude Code bugs:
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#14061](https://github.com/anthropics/claude-code/issues/14061) | `/plugin update` does not invalidate plugin cache | Open |
+| [#15642](https://github.com/anthropics/claude-code/issues/15642) | CLAUDE_PLUGIN_ROOT points to stale version | Open |
+| [#15369](https://github.com/anthropics/claude-code/issues/15369) | Plugin uninstall does not clear cached files | Open |
+| [#16453](https://github.com/anthropics/claude-code/issues/16453) | Plugin cache grows indefinitely | Open |
+
+## Installation
+
+```bash
+/plugin install utils@claude-tools
+```
+
+## Usage
+
+### Clear Single Plugin Cache
+
+```bash
+# Clear cache for a specific plugin (default marketplace: claude-tools)
+/utils:clear-plugin-cache cvi
+
+# Clear cache for a plugin from another marketplace
+/utils:clear-plugin-cache some-plugin --marketplace other-market
+```
+
+### Clear All Plugin Caches
+
+```bash
+# Clear all plugin caches for a marketplace (requires confirmation)
+/utils:clear-plugin-cache --all --marketplace claude-tools
+```
+
+### Dry Run
+
+Preview what would be deleted without actually deleting:
+
+```bash
+/utils:clear-plugin-cache cvi --dry-run
+/utils:clear-plugin-cache --all --marketplace claude-tools --dry-run
+```
+
+## After Clearing Cache
+
+After clearing the cache, **restart Claude Code** for changes to take effect.
+
+## Cache Location
+
+Plugin caches are stored at:
+```
+~/.claude/plugins/cache/<marketplace>/<plugin>/
+```
+
+## License
+
+MIT

--- a/plugins/utils/commands/clear-plugin-cache.md
+++ b/plugins/utils/commands/clear-plugin-cache.md
@@ -1,0 +1,47 @@
+---
+name: clear-plugin-cache
+description: Clear plugin cache to fix stale version issues after /plugin update
+argument-hint: <plugin-name> [--marketplace <name>] [--all] [--dry-run]
+allowed-tools:
+  - Bash
+---
+
+# Clear Plugin Cache
+
+This command clears the plugin cache to resolve stale version issues caused by Claude Code's cache invalidation bug.
+
+## Background
+
+When running `/plugin update`, Claude Code updates the marketplace git repository but does not invalidate the cached plugin files. This causes updated plugins to not work correctly until the cache is manually cleared.
+
+Related issues:
+- [#14061](https://github.com/anthropics/claude-code/issues/14061) - `/plugin update` does not invalidate plugin cache
+- [#15642](https://github.com/anthropics/claude-code/issues/15642) - CLAUDE_PLUGIN_ROOT points to stale version
+
+## Usage
+
+Execute the cache clear script with the provided arguments:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh $ARGUMENTS
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `plugin-name` | Name of the plugin to clear cache for |
+| `--marketplace <name>` | Specify marketplace (default: claude-tools) |
+| `--all` | Clear all plugin caches for the specified marketplace |
+| `--dry-run` | Show what would be deleted without actually deleting |
+
+## Examples
+
+- Clear single plugin: `/utils:clear-plugin-cache cvi`
+- Clear with marketplace: `/utils:clear-plugin-cache plugin --marketplace other-market`
+- Clear all: `/utils:clear-plugin-cache --all --marketplace claude-tools`
+- Dry run: `/utils:clear-plugin-cache cvi --dry-run`
+
+## After Clearing
+
+After clearing the cache, restart Claude Code for changes to take effect.

--- a/plugins/utils/scripts/clear-plugin-cache.sh
+++ b/plugins/utils/scripts/clear-plugin-cache.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+# Clear Plugin Cache - Workaround for Claude Code cache invalidation bug
+# https://github.com/anthropics/claude-code/issues/14061
+
+set -e
+
+# Default values
+MARKETPLACE="claude-tools"
+MARKETPLACE_SPECIFIED=false
+PLUGIN_NAME=""
+ALL_PLUGINS=false
+DRY_RUN=false
+CACHE_BASE_DIR="$HOME/.claude/plugins/cache"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored message
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Show usage
+usage() {
+    cat << EOF
+Usage: clear-plugin-cache <plugin-name> [options]
+       clear-plugin-cache --all --marketplace <name>
+
+Clear plugin cache to fix stale version issues.
+
+Arguments:
+  plugin-name              Name of the plugin to clear cache for
+
+Options:
+  --marketplace <name>     Marketplace name (default: claude-tools)
+  --all                    Clear all plugin caches for the marketplace
+  --dry-run                Show what would be deleted without deleting
+  -h, --help               Show this help message
+
+Examples:
+  clear-plugin-cache cvi
+  clear-plugin-cache cvi --dry-run
+  clear-plugin-cache plugin --marketplace other-market
+  clear-plugin-cache --all --marketplace claude-tools
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --marketplace)
+            MARKETPLACE="$2"
+            MARKETPLACE_SPECIFIED=true
+            shift 2
+            ;;
+        --all)
+            ALL_PLUGINS=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            if [[ -z "$PLUGIN_NAME" ]]; then
+                PLUGIN_NAME="$1"
+            else
+                print_error "Unexpected argument: $1"
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate arguments
+if [[ "$ALL_PLUGINS" == true ]]; then
+    if [[ "$MARKETPLACE_SPECIFIED" == false ]]; then
+        # --all requires explicit --marketplace for safety
+        print_error "--all requires --marketplace to be explicitly specified"
+        echo ""
+        echo "Example: clear-plugin-cache --all --marketplace claude-tools"
+        exit 1
+    fi
+elif [[ -z "$PLUGIN_NAME" ]]; then
+    print_error "Plugin name is required (or use --all with --marketplace)"
+    echo ""
+    usage
+    exit 1
+fi
+
+# Build cache path
+MARKETPLACE_CACHE_DIR="$CACHE_BASE_DIR/$MARKETPLACE"
+
+# Check if marketplace cache directory exists
+if [[ ! -d "$MARKETPLACE_CACHE_DIR" ]]; then
+    print_warning "Marketplace cache directory not found: $MARKETPLACE_CACHE_DIR"
+    exit 0
+fi
+
+# Function to get directory size
+get_dir_size() {
+    local dir="$1"
+    if [[ -d "$dir" ]]; then
+        du -sh "$dir" 2>/dev/null | cut -f1
+    else
+        echo "0B"
+    fi
+}
+
+# Function to delete a plugin cache
+delete_plugin_cache() {
+    local plugin_dir="$1"
+    local plugin_name=$(basename "$plugin_dir")
+    local size=$(get_dir_size "$plugin_dir")
+
+    if [[ "$DRY_RUN" == true ]]; then
+        print_info "[DRY-RUN] Would delete: $plugin_dir ($size)"
+    else
+        rm -rf "$plugin_dir"
+        print_success "Deleted: $plugin_dir ($size)"
+    fi
+}
+
+# Clear cache
+if [[ "$ALL_PLUGINS" == true ]]; then
+    # Confirmation for --all
+    if [[ "$DRY_RUN" == false ]]; then
+        echo ""
+        print_warning "This will delete ALL plugin caches for marketplace: $MARKETPLACE"
+        echo ""
+
+        # List plugins to be deleted
+        plugin_count=0
+        for plugin_dir in "$MARKETPLACE_CACHE_DIR"/*; do
+            if [[ -d "$plugin_dir" ]]; then
+                echo "  - $(basename "$plugin_dir") ($(get_dir_size "$plugin_dir"))"
+                ((plugin_count++))
+            fi
+        done
+
+        if [[ $plugin_count -eq 0 ]]; then
+            print_warning "No plugin caches found"
+            exit 0
+        fi
+
+        echo ""
+        read -p "Are you sure you want to delete $plugin_count plugin cache(s)? [y/N] " -n 1 -r
+        echo ""
+
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_info "Cancelled"
+            exit 0
+        fi
+    fi
+
+    # Delete all plugins
+    for plugin_dir in "$MARKETPLACE_CACHE_DIR"/*; do
+        if [[ -d "$plugin_dir" ]]; then
+            delete_plugin_cache "$plugin_dir"
+        fi
+    done
+else
+    # Single plugin
+    PLUGIN_CACHE_DIR="$MARKETPLACE_CACHE_DIR/$PLUGIN_NAME"
+
+    if [[ ! -d "$PLUGIN_CACHE_DIR" ]]; then
+        print_warning "Plugin cache not found: $PLUGIN_CACHE_DIR"
+        echo ""
+        echo "Available plugins in $MARKETPLACE:"
+        for plugin_dir in "$MARKETPLACE_CACHE_DIR"/*; do
+            if [[ -d "$plugin_dir" ]]; then
+                echo "  - $(basename "$plugin_dir")"
+            fi
+        done
+        exit 0
+    fi
+
+    delete_plugin_cache "$PLUGIN_CACHE_DIR"
+fi
+
+# Final message
+echo ""
+if [[ "$DRY_RUN" == true ]]; then
+    print_info "Dry run complete. No files were deleted."
+else
+    print_success "Cache cleared successfully!"
+    echo ""
+    print_info "Please restart Claude Code for changes to take effect."
+fi


### PR DESCRIPTION
## Summary

- Add `utils` plugin providing utility commands for Claude Code plugin management
- Implement `/utils:clear-plugin-cache` command as a workaround for cache invalidation bug

## Background

Claude Code's `/plugin update` does not invalidate plugin cache, causing stale versions to be used.

Related issues:
- [#14061](https://github.com/anthropics/claude-code/issues/14061) - `/plugin update` does not invalidate plugin cache
- [#15642](https://github.com/anthropics/claude-code/issues/15642) - CLAUDE_PLUGIN_ROOT points to stale version

## Features

- Clear single plugin cache: `/utils:clear-plugin-cache cvi`
- Clear all plugin caches: `/utils:clear-plugin-cache --all --marketplace claude-tools`
- Support for other marketplaces: `--marketplace` option
- Preview mode: `--dry-run` option
- Confirmation prompt for `--all` operations

## Test plan

- [x] `--help` shows usage
- [x] Single plugin cache clear with `--dry-run`
- [x] `--all` without `--marketplace` shows error
- [x] `--all --marketplace claude-tools --dry-run` lists all plugins
- [x] Non-existent plugin shows warning and available plugins

🤖 Generated with [Claude Code](https://claude.ai/code)