### PR TITLE
fix(utils): remove name field from command to fix prefix

### DIFF
--- a/plugins/utils/commands/clear-plugin-cache.md
+++ b/plugins/utils/commands/clear-plugin-cache.md
@@ -1,5 +1,4 @@
 ---
-name: clear-plugin-cache
 description: Clear plugin cache to fix stale version issues after /plugin update
 argument-hint: <plugin-name> [--marketplace <name>] [--all] [--dry-run]
 allowed-tools:


### PR DESCRIPTION
## Summary

- Remove `name` field from command frontmatter to fix missing plugin prefix

## Problem

The command was showing as `/clear-plugin-cache` instead of `/utils:clear-plugin-cache`.

## Cause

When a command has an explicit `name:` field in frontmatter, the plugin prefix is not automatically added.

## Fix

Remove the `name:` field. The command name is derived from the filename, and the plugin prefix is added from plugin.json.

## Test plan

- [ ] After clearing cache and restarting, command should show as `/utils:clear-plugin-cache`

🤖 Generated with [Claude Code](https://claude.ai/code)