### PR TITLE
fix(code-review): use pr-review-toolkit agent for code review

### DIFF
--- a/plugins/code-review/skills/review-commit/SKILL.md
+++ b/plugins/code-review/skills/review-commit/SKILL.md
@@ -1,15 +1,14 @@
 ---
-name: review-commit
 description: "Run code review and approve for commit (integrates with check-code-review.sh hook)"
 ---
 
 # Code Review Skill
 
-Review staged changes and approve them for commit.
+Review staged changes using the code-reviewer agent and approve them for commit.
 
 ## Overview
 
-This skill performs code review on staged git changes and, if approved, saves a hash that allows the pre-commit hook to verify the review was completed.
+This skill performs automated code review on staged git changes using the `pr-review-toolkit:code-reviewer` agent. If the review passes, it saves a hash that allows the pre-commit hook to verify the review was completed.
 
 ## Execution Steps
 
@@ -23,72 +22,37 @@ git diff --cached --stat
 
 **If no staged changes**: Report "No staged changes to review" and exit.
 
-### Step 2: Get Diff for Review
+### Step 2: Launch Code Reviewer Agent
 
-Get the full diff of staged changes:
+Use the Task tool to launch the `pr-review-toolkit:code-reviewer` agent:
 
-```bash
-git diff --cached
+```
+Task tool parameters:
+- subagent_type: "pr-review-toolkit:code-reviewer"
+- prompt: "Review the staged changes (git diff --cached) for this commit. Check for CLAUDE.md compliance, bugs, and code quality issues. Report only issues with confidence >= 80."
+- description: "Review staged changes"
 ```
 
-### Step 3: Perform Code Review
+The agent will:
+- Check CLAUDE.md compliance
+- Detect bugs and logic errors
+- Evaluate code quality
+- Score issues by confidence (only report >= 80)
 
-Review the staged changes for:
+### Step 3: Handle Review Results
 
-1. **Code Quality**
-   - Readability and maintainability
-   - Proper error handling
-   - No hardcoded values that should be configurable
+**If issues found (confidence >= 80)**:
+- Present the issues to the user
+- Do NOT approve the commit
+- Suggest fixes
 
-2. **Security**
-   - No exposed secrets or credentials
-   - No SQL injection vulnerabilities
-   - No XSS vulnerabilities
-   - Input validation where needed
+**If no issues found**:
+- Report that the review passed
+- Proceed to Step 4
 
-3. **Best Practices**
-   - Follows project conventions (check CLAUDE.md if exists)
-   - Appropriate naming conventions
-   - No unnecessary code duplication
+### Step 4: Approve for Commit
 
-4. **Logic**
-   - No obvious bugs
-   - Edge cases handled
-   - Correct algorithm usage
-
-### Step 4: Report Findings
-
-Present review findings to the user:
-
-**If issues found**:
-```
-## Code Review Results
-
-### Issues Found
-
-1. **[Severity: High/Medium/Low]** Description of issue
-   - File: path/to/file.ts:line
-   - Suggestion: How to fix
-
-### Summary
-- Total issues: N
-- High: N, Medium: N, Low: N
-
-Please address the issues before committing.
-```
-
-**If no issues**:
-```
-## Code Review Results
-
-No issues found. Code looks good!
-
-Approving for commit...
-```
-
-### Step 5: Approve (if passed)
-
-If review passes with no blocking issues, run the approval script:
+If review passes, run the approval script:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-review.sh
@@ -101,34 +65,14 @@ This saves a hash of the staged changes that the pre-commit hook can verify.
 This skill works with `check-code-review.sh` as a pre-commit hook:
 
 1. Hook blocks `git commit` if no review approval exists
-2. This skill performs review and creates approval hash
-3. Subsequent `git commit` proceeds if hash matches
-
-### Setting Up the Hook (Optional)
-
-Add to your project's `.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-code-review.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+2. User runs `/code:review-commit`
+3. This skill launches code-reviewer agent
+4. If passed, approval hash is saved
+5. Subsequent `git commit` proceeds if hash matches
 
 ## Notes
 
-- Review is based on staged changes only
-- Unstaged changes are ignored
+- Review is based on staged changes only (`git diff --cached`)
+- Uses `pr-review-toolkit:code-reviewer` agent for automated review
 - Hash changes if staged content changes (requires re-review)
 - Approval file is automatically deleted after successful commit


### PR DESCRIPTION
## Summary

- Update review-commit skill to use `pr-review-toolkit:code-reviewer` agent
- Remove `name` field from frontmatter (fixes prefix issue)

## Changes

**Before**: Manual review steps described in SKILL.md (Claude follows checklist)

**After**: Automated review using specialized code-reviewer agent via Task tool

## Benefits

- Automated code review with confidence scoring
- Consistent CLAUDE.md compliance checking
- Bug detection and code quality evaluation
- Only high-confidence issues (>= 80) are reported

## Test plan

- [ ] Run `/code:review-commit` with staged changes
- [ ] Verify code-reviewer agent is launched
- [ ] Verify approval hash is saved on successful review

🤖 Generated with [Claude Code](https://claude.ai/code)