### PR TITLE
feat(code): add review-pr skill for PR self-review

### DIFF
--- a/plugins/code-review/skills/review-pr/SKILL.md
+++ b/plugins/code-review/skills/review-pr/SKILL.md
@@ -1,0 +1,44 @@
+---
+description: "Self-review a PR before requesting reviewers. Use when user asks to review a PR, check PR quality, or validate PR changes before merge."
+---
+
+# Review PR
+
+Self-review a pull request using pr-review-toolkit agents.
+
+## Execution
+
+### Step 1: Get PR Number
+
+If argument provided: Use that PR number
+If no argument: Detect from current branch
+
+```bash
+gh pr view --json number -q '.number'
+```
+
+If no PR found: Report error and exit.
+
+### Step 2: Run PR Review
+
+Launch Task tool:
+
+```
+subagent_type: "pr-review-toolkit:review-pr"
+prompt: "Review PR #<number>. Run comprehensive review including code quality, errors, and test coverage."
+description: "PR review"
+```
+
+### Step 3: Report Results
+
+**If issues found**:
+- Present all issues
+- Suggest fixes
+
+**If no issues**:
+- Report: "PR #<number> passed review. Ready for merge."
+
+## Notes
+
+- This skill only reviews, does NOT merge
+- User decides next action (merge, request reviewers, etc.)


### PR DESCRIPTION
## Summary
- PR のセルフレビュー用スキル `/code:review-pr` を追加
- `pr-review-toolkit:review-pr` エージェントを使用して包括的レビューを実行
- レビュー結果を報告するのみ（マージ操作は行わない）

## Test plan
- [ ] `/code:review-pr` を実行してスキルが動作することを確認
- [ ] PR 番号を引数で指定してレビューできることを確認
- [ ] 引数なしで現在のブランチから PR を検出できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)