### PR TITLE
fix(code): enforce approval script usage in review-commit skill

### DIFF
--- a/plugins/code-review/skills/review-commit/SKILL.md
+++ b/plugins/code-review/skills/review-commit/SKILL.md
@@ -48,7 +48,7 @@ Wait for the agent to complete and return results.
 
 ### Step 4: Approve for Commit
 
-If review passes, run the approval script:
+**MANDATORY**: If review passes, you MUST run the approval script. Do NOT approve manually or skip this step.
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-review.sh
@@ -70,4 +70,6 @@ This skill works with `check-code-review.sh` as a pre-commit hook:
 
 - ALWAYS use Task tool with `pr-review-toolkit:code-reviewer` agent
 - NEVER review code manually - delegate to the agent
+- ALWAYS run `approve-review.sh` script after review passes
+- NEVER approve manually or skip the approval script
 - Hash changes if staged content changes (requires re-review)


### PR DESCRIPTION
## Summary
- review-commit スキルの Step 4 に MANDATORY 言語を追加
- 承認スクリプト (`approve-review.sh`) の実行を必須化
- 手動承認やスクリプトスキップを明示的に禁止

## Background
他プロジェクトで `/code:review-commit` 実行時に、Claude が承認スクリプトを使わず手動承認してしまう問題が発生。
Task ツール使用と同様に、MANDATORY 言語を追加して遵守を強化。

## Changes
- `plugins/code-review/skills/review-commit/SKILL.md`
  - Step 4: MANDATORY 言語追加
  - Important セクション: 承認スクリプトルール追加

## Test plan
- [ ] `/code:review-commit` 実行時に `approve-review.sh` が呼ばれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)