### PR TITLE
feat(cvi): add clarification rules to English Practice mode

### DIFF
--- a/plugins/cvi/scripts/inject-cvi-context.sh
+++ b/plugins/cvi/scripts/inject-cvi-context.sh
@@ -49,6 +49,11 @@ if [ "$ENGLISH_PRACTICE" = "on" ]; then
    ⚠️  THIS DOES NOT CHANGE CLAUDE'S RESPONSE LANGUAGE
    → You MUST respond in the language set by Claude Code's "language" setting
    → English Practice is for USER input only, not Claude output
+
+   🔴 CLARIFICATION RULES (user is practicing English):
+   → If user's English is unclear or ambiguous, ASK for clarification
+   → Do NOT guess the meaning - confirm before acting
+   → When user asks "How do you say X in English?", answer the question
 EOF
 fi
 


### PR DESCRIPTION
## Summary
- English Practice モードに明確化ルールを追加
- ユーザーの英語が不明確な場合は推測せず確認する
- 語彙の質問に回答するルールを追加

## 背景
ユーザーが英語を練習中のため、曖昧な表現を誤解せず確認を求めるべき。

## Test plan
- [ ] `bash plugins/cvi/scripts/inject-cvi-context.sh` で新しいルールが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)