### PR TITLE
feat(cvi): add UserPromptSubmit hook to enforce CVI settings

### DIFF
--- a/plugins/cvi/hooks/hooks.json
+++ b/plugins/cvi/hooks/hooks.json
@@ -33,6 +33,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/kill-voice.sh",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/show-cvi-settings.sh",
+            "timeout": 2000
           }
         ]
       }

--- a/plugins/cvi/scripts/show-cvi-settings.sh
+++ b/plugins/cvi/scripts/show-cvi-settings.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# UserPromptSubmit: Show CVI settings (Claude interprets via skill knowledge)
+CONFIG="$HOME/.cvi/config"
+[ -f "$CONFIG" ] || exit 0
+grep -E "^(CVI_ENABLED|VOICE_LANG|ENGLISH_PRACTICE)=" "$CONFIG" 2>/dev/null | sed 's/^/CVI: /'

--- a/plugins/cvi/skills/voice-integration/SKILL.md
+++ b/plugins/cvi/skills/voice-integration/SKILL.md
@@ -76,6 +76,22 @@ The [VOICE] tag language is controlled by `VOICE_LANG` in `~/.cvi/config`:
 [VOICE]設定ファイルを3つ更新しました。テストは全て成功しています。[/VOICE]
 ```
 
+## English Practice Mode
+
+When `ENGLISH_PRACTICE=on` in `~/.cvi/config`:
+
+**If user input contains non-ASCII characters (Japanese, etc.):**
+1. Show English equivalent: `> "English instruction"`
+2. Prompt: `your turn`
+3. **Wait for user to repeat in English**
+4. **Then execute the instruction**
+
+**Important clarifications:**
+- This mode affects USER prompts only, not Claude's response language
+- Claude responds in the language set by Claude Code's `language` setting
+- If user's English is unclear, ask for clarification before acting
+- When user asks "How do you say X in English?", answer the question
+
 ## Fallback Behavior
 
 If no [VOICE] tag is present, the first 200 characters of the response are automatically read aloud. Using a [VOICE] tag provides better control over what is spoken.


### PR DESCRIPTION
## Summary
- 毎プロンプトでCVI設定を注入するUserPromptSubmitフックを追加
- シンプルなアプローチ：設定値を出力するだけ（4行）、ルール解釈はClaudeに任せる
- English Practiceモードのルールをスキルドキュメントに追加

## Changes
| ファイル | 変更 |
|----------|------|
| `plugins/cvi/scripts/show-cvi-settings.sh` | 新規（4行） |
| `plugins/cvi/hooks/hooks.json` | UserPromptSubmitにフック追加 |
| `plugins/cvi/skills/voice-integration/SKILL.md` | English Practiceルール追加 |

## Design Philosophy
- 複雑なシェルロジックを避け、設定値を出力するだけ
- Claudeがスキルの知識に基づいてルールを自律的に適用
- PR review toolkitパターンに倣ったシンプルな設計

## Test plan
- [x] スクリプト単体テスト: `bash plugins/cvi/scripts/show-cvi-settings.sh`
- [ ] Claude Code再起動後の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)