### PR TITLE
feat(cvi): replace command hook with prompt-based hook

### DIFF
--- a/plugins/cvi/hooks/hooks.json
+++ b/plugins/cvi/hooks/hooks.json
@@ -35,9 +35,9 @@
             "timeout": 5000
           },
           {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/show-cvi-settings.sh",
-            "timeout": 2000
+            "type": "prompt",
+            "prompt": "You are a CVI (Claude Voice Integration) rule enforcer. Read ~/.cvi/config to check settings.\n\n**RULES TO ENFORCE:**\n\n1. **[VOICE] TAG LANGUAGE**: Check VOICE_LANG setting. Claude MUST use this language for [VOICE] tags at the end of task completions.\n   - If VOICE_LANG=en: [VOICE] must be in English\n   - If VOICE_LANG=ja: [VOICE] must be in Japanese\n\n2. **ENGLISH PRACTICE MODE**: Check ENGLISH_PRACTICE setting.\n   - If ENGLISH_PRACTICE=on AND user input contains non-ASCII characters (Japanese, Chinese, etc.):\n     → Claude MUST first show English equivalent: > \"English translation\"\n     → Claude MUST say: \"your turn\"\n     → Claude MUST WAIT for user to repeat in English\n     → Claude must NOT execute the instruction directly\n   - If ENGLISH_PRACTICE=off or input is ASCII-only: proceed normally\n\n3. **CLARIFICATION**: If user's English is unclear, ask for clarification before acting.\n\n**OUTPUT**: Return a systemMessage with the applicable rules based on current settings and user input.",
+            "timeout": 10000
           }
         ]
       }


### PR DESCRIPTION
## Summary
- CVIルールをより確実に強制するため、command hookからprompt-based hookに変更
- LLMがCVI設定を評価してsystemMessageでルールを返す

## Background
- 以前のcommand hookは設定値を出力するだけでClaudeが無視する可能性があった
- prompt-based hookはLLMで評価するため、より確実にルールを適用できる

## Changes
| Before | After |
|--------|-------|
| `show-cvi-settings.sh` (command) | prompt-based hook |
| 設定値を出力するだけ | LLMがルールを評価して返す |

## Rules Enforced
1. **VOICE_LANG**: [VOICE]タグの言語設定
2. **ENGLISH_PRACTICE**: 非英語入力時の英訳練習モード
3. **CLARIFICATION**: 不明確な英語入力時の確認

## Test plan
- [ ] Claude Code再起動後、日本語入力でENGLISH_PRACTICEが機能することを確認
- [ ] [VOICE]タグがVOICE_LANG設定に従うことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)