### PR TITLE
feat(cvi): replace prompt-based hook with command hook

### DIFF
--- a/plugins/cvi/hooks/hooks.json
+++ b/plugins/cvi/hooks/hooks.json
@@ -35,9 +35,9 @@
             "timeout": 5000
           },
           {
-            "type": "prompt",
-            "prompt": "You are a CVI (Claude Voice Integration) rule enforcer. Read ~/.cvi/config to check settings.\n\n**RULES TO ENFORCE:**\n\n1. **[VOICE] TAG LANGUAGE**: Check VOICE_LANG setting. Claude MUST use this language for [VOICE] tags at the end of task completions.\n   - If VOICE_LANG=en: [VOICE] must be in English\n   - If VOICE_LANG=ja: [VOICE] must be in Japanese\n\n2. **ENGLISH PRACTICE MODE**: Check ENGLISH_PRACTICE setting.\n   - If ENGLISH_PRACTICE=on AND user input contains non-ASCII characters (Japanese, Chinese, etc.):\n     → Claude MUST first show English equivalent: > \"English translation\"\n     → Claude MUST say: \"your turn\"\n     → Claude MUST WAIT for user to repeat in English\n     → Claude must NOT execute the instruction directly\n   - If ENGLISH_PRACTICE=off or input is ASCII-only: proceed normally\n\n3. **CLARIFICATION**: If user's English is unclear, ask for clarification before acting.\n\n**OUTPUT**: Return a systemMessage with the applicable rules based on current settings and user input.",
-            "timeout": 10000
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/enforce-cvi-rules.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/plugins/cvi/scripts/enforce-cvi-rules.sh
+++ b/plugins/cvi/scripts/enforce-cvi-rules.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# UserPromptSubmit hook: Enforce CVI rules based on config
+
+CONFIG_FILE="$HOME/.cvi/config"
+
+# Read config values
+if [ -f "$CONFIG_FILE" ]; then
+    VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
+    ENGLISH_PRACTICE=$(grep "^ENGLISH_PRACTICE=" "$CONFIG_FILE" | cut -d'=' -f2)
+else
+    # Config file not found - use defaults silently
+    VOICE_LANG="ja"
+    ENGLISH_PRACTICE="off"
+fi
+
+# Set defaults for empty values
+VOICE_LANG=${VOICE_LANG:-ja}
+ENGLISH_PRACTICE=${ENGLISH_PRACTICE:-off}
+
+# Determine language display
+if [ "$VOICE_LANG" = "en" ]; then
+    VOICE_LANG_DISPLAY="English"
+else
+    VOICE_LANG_DISPLAY="Japanese"
+fi
+
+# Output rules as systemMessage
+cat << EOF
+CVI Rule Enforcement (from ~/.cvi/config):
+
+1. [VOICE] TAG: Use ${VOICE_LANG_DISPLAY} (VOICE_LANG=${VOICE_LANG})
+EOF
+
+# English Practice mode rules
+if [ "$ENGLISH_PRACTICE" = "on" ]; then
+    cat << 'EOF'
+
+2. ENGLISH PRACTICE MODE: ON
+   When user input contains Japanese:
+   → Show English equivalent: > "English translation"
+   → Say: "your turn"
+   → Wait for user to repeat in English
+   → Do NOT execute until user provides English input
+EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- prompt-based hookをcommand hookに変更
- `enforce-cvi-rules.sh`スクリプトで設定を読み取りルールを出力

## Background
- prompt-based hookのLLMはファイルシステムにアクセスできない
- 「Read ~/.cvi/config」と指示しても実際には読めない
- command hookならシェルスクリプトで確実に設定を読める

## Changes
| ファイル | 変更 |
|----------|------|
| `plugins/cvi/hooks/hooks.json` | prompt → command hook |
| `plugins/cvi/scripts/enforce-cvi-rules.sh` | 新規作成 |

## Test plan
- [ ] Claude Code再起動後、CVI設定が正しく読み込まれることを確認
- [ ] ENGLISH_PRACTICE=onの時にルールが出力されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)