### PR TITLE
refactor(plugins): switch to hash-based versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,15 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 ### バージョン管理ルール
 
-**PRマージ前**:
-- 変更内容に応じてプラグインのセマンティックバージョンを更新
-  - `MAJOR`: 後方互換性のない変更
-  - `MINOR`: 後方互換性のある機能追加
-  - `PATCH`: バグ修正・メンテナンス
-- 対象ファイル: `plugins/<plugin>/.claude-plugin/plugin.json`
+**Hash-based Versioning**:
+- プラグインはGit commit hashで自動管理（Anthropic公式と同様）
+- `plugin.json`にversionフィールドは不要
+- Claude Codeがインストール時にcommit SHAを記録
+
+**利点**:
+- 手動バージョン更新のオーバーヘッド削減
+- 頻繁な修正に対応しやすい
+- 正確なコード追跡が可能
 
 **PRマージ後**:
 - Subtree管理プラグインは各リポジトリに変更を反映

--- a/plugins/chezmoi/.claude-plugin/plugin.json
+++ b/plugins/chezmoi/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "chezmoi",
-  "version": "1.0.1",
   "description": "Dotfiles management integration for Claude Code using chezmoi",
   "author": {
     "name": "SignalCompose",

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "code",
-  "version": "1.1.0",
   "description": "Code review workflow integration for git commits",
   "author": {
     "name": "SignalCompose",

--- a/plugins/cvi/.claude-plugin/plugin.json
+++ b/plugins/cvi/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "cvi",
-  "version": "1.1.0",
   "description": "Claude Voice Integration - Voice notifications for Claude Code on macOS",
   "author": {
     "name": "signalcompose",

--- a/plugins/utils/.claude-plugin/plugin.json
+++ b/plugins/utils/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "utils",
-  "version": "1.0.1",
   "description": "Utility commands for Claude Code plugin management",
   "author": {
     "name": "SignalCompose"

--- a/plugins/ypm/.claude-plugin/plugin.json
+++ b/plugins/ypm/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "ypm",
-  "version": "1.0.1",
   "description": "Multi-project progress tracking system powered by Claude Code. Automatically tracks status of multiple projects from Git history and documentation.",
   "author": {
     "name": "Hiroshi Yamato",


### PR DESCRIPTION
## Summary
- plugin.jsonからversionフィールドを削除し、Anthropic公式プラグインと同様のGit commit hashベースのバージョン管理に移行
- CLAUDE.mdのバージョン管理ルールを更新

## 変更ファイル
- `plugins/cvi/.claude-plugin/plugin.json` - version削除
- `plugins/ypm/.claude-plugin/plugin.json` - version削除
- `plugins/code-review/.claude-plugin/plugin.json` - version削除
- `plugins/chezmoi/.claude-plugin/plugin.json` - version削除
- `plugins/utils/.claude-plugin/plugin.json` - version削除
- `CLAUDE.md` - バージョン管理ルール更新

## 利点
- 手動バージョン更新のオーバーヘッド削減
- 頻繁な修正に対応しやすい
- Claude Codeがインストール時にcommit SHAを自動記録

## Test plan
- [x] 全てのplugin.jsonが有効なJSON
- [ ] PRマージ後、`/plugin marketplace update claude-tools`でマーケットプレイス更新
- [ ] プラグイン再インストールでhashベースバージョンを確認

🤖 Generated with [Claude Code](https://claude.ai/code)