### PR TITLE
fix(marketplace): add kiro plugin to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,6 +55,13 @@
       "source": "./plugins/gemini",
       "category": "productivity",
       "homepage": "https://github.com/signalcompose/claude-tools/tree/main/plugins/gemini"
+    },
+    {
+      "name": "kiro",
+      "description": "AWS Kiro CLI integration for research and troubleshooting",
+      "source": "./plugins/kiro",
+      "category": "developer-tools",
+      "homepage": "https://github.com/signalcompose/claude-tools/tree/main/plugins/kiro"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- kiro プラグインを marketplace.json に登録

## 原因
PR #38 で plugins/kiro/ を追加したが、marketplace.json への登録が漏れていた

## 修正内容
- .claude-plugin/marketplace.json に kiro プラグインのエントリを追加

## Test plan
- [ ] `/plugin update` 後に kiro プラグインが表示されることを確認
- [ ] `/plugin install kiro@claude-tools` でインストール可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)