### PR TITLE
feat(kiro): implement readonly mode (no web search)

### DIFF
--- a/plugins/kiro/README.md
+++ b/plugins/kiro/README.md
@@ -1,12 +1,13 @@
 # Kiro Plugin
 
-AWS Kiro CLI integration for Claude Code.
+AWS Kiro CLI integration for Claude Code - your AWS expert assistant.
 
 ## Features
 
-- **AWS Research**: Query AWS topics and documentation using Kiro CLI
+- **AWS Expert Knowledge**: Get answers from Kiro's trained AWS expertise
 - **Troubleshooting**: Investigate AWS errors and issues
 - **Best Practices**: Get AWS architecture recommendations
+- **Readonly Mode**: Uses Kiro's training knowledge only (no web search)
 
 ## Prerequisites
 
@@ -51,6 +52,18 @@ No additional configuration required. The plugin uses:
 - 120-second timeout for all operations
 
 ## Technical Details
+
+### Readonly Mode (No Web Search)
+
+This plugin runs Kiro in **readonly mode** by default:
+- Kiro answers using its trained AWS knowledge only
+- Web search and external tools are disabled
+- This ensures reliable operation in non-interactive mode
+
+**Why readonly mode?**
+- `kiro-cli --no-interactive` cannot approve tool usage
+- Web search would fail without `--trust-all-tools` flag
+- For web search, use Claude's built-in WebSearch or Gemini instead
 
 ### Context Isolation
 

--- a/plugins/kiro/scripts/kiro-ask.sh
+++ b/plugins/kiro/scripts/kiro-ask.sh
@@ -35,8 +35,14 @@ if [ -z "$PROMPT" ]; then
     exit 1
 fi
 
-echo "Executing Kiro CLI..."
-echo "Prompt: $PROMPT"
+# Readonly mode: Instruct Kiro to use only its training knowledge (no web search)
+# This avoids tool approval issues in non-interactive mode
+READONLY_PREFIX="Without using web search or any external tools, answer from your training knowledge as an AWS expert:"
+FULL_PROMPT="$READONLY_PREFIX $PROMPT"
+
+echo "Executing Kiro CLI (using training knowledge only)..."
+echo "Query: $PROMPT"
+echo "(readonly mode: web search disabled via prompt instruction)"
 echo "---"
 
 # Ensure TMPDIR is writable (prevents some SQLite issues)
@@ -58,9 +64,9 @@ fi
 # Execute with timeout (120 seconds) or without if no timeout command available
 set +e  # Temporarily disable exit on error to capture exit code
 if [ -n "$TIMEOUT_CMD" ]; then
-    OUTPUT=$($TIMEOUT_CMD 120 kiro-cli chat --no-interactive "$PROMPT" 2>&1)
+    OUTPUT=$($TIMEOUT_CMD 120 kiro-cli chat --no-interactive "$FULL_PROMPT" 2>&1)
 else
-    OUTPUT=$(kiro-cli chat --no-interactive "$PROMPT" 2>&1)
+    OUTPUT=$(kiro-cli chat --no-interactive "$FULL_PROMPT" 2>&1)
 fi
 
 EXIT_CODE=$?

--- a/plugins/kiro/skills/kiro-research/SKILL.md
+++ b/plugins/kiro/skills/kiro-research/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: kiro-research
 description: |
-  Research AWS topics or troubleshoot errors using Kiro CLI.
+  Research AWS topics using Kiro CLI as an AWS expert (readonly mode).
   Use for: AWS documentation, error investigation,
   CloudFormation/CDK questions, AWS best practices.
+  Note: Uses Kiro's training knowledge only (no web search).
 context: fork
 agent: Explore
 allowed-tools: Bash
@@ -12,6 +13,7 @@ allowed-tools: Bash
 # Kiro Research Skill
 
 This skill provides integration with Kiro CLI for AWS research and troubleshooting tasks.
+Kiro runs in **readonly mode** - answering from its trained AWS expertise without web search.
 
 ## Prerequisites
 
@@ -78,4 +80,6 @@ For security, prompts are sanitized before execution:
 
 ## Notes
 
-This skill uses `context: fork` to isolate large outputs from the main conversation context.
+- This skill uses `context: fork` to isolate large outputs from the main conversation context.
+- **Readonly mode**: Kiro answers from its training knowledge only (no web search or external tools).
+- For web search needs, use Claude's built-in WebSearch or Gemini instead.


### PR DESCRIPTION
## Summary

Kiro プラグインを **readonly モード** で実装しました。

### 変更内容

- **kiro-ask.sh**: プロンプトに readonly prefix を追加して web search を無効化
- **README.md**: Features と Technical Details を更新
- **SKILL.md**: スキル説明を更新

### 技術的背景

- `kiro-cli --no-interactive` モードではツール承認ができない
- Kiro はデフォルトで web_search を使おうとするため、承認が必要でエラーになる
- プロンプトで「外部ツールを使わないで」と指示することで回避

### Readonly モードの利点

1. **安定動作**: web search の承認問題を回避
2. **AWS エキスパート**: Kiro の訓練知識から回答
3. **役割分担**: web search は Claude の WebSearch や Gemini を使用

## Test Plan

- [x] `kiro-ask.sh` が readonly モードで動作することを確認
- [x] Kiro が web search なしで AWS の質問に回答することを確認
- [x] 出力メッセージが透明性を確保していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)