### PR TITLE
docs(chezmoi): add diff output interpretation guide

### DIFF
--- a/plugins/chezmoi/commands/commit.md
+++ b/plugins/chezmoi/commands/commit.md
@@ -18,6 +18,17 @@ chezmoi status
 
 **If no changes**: Report "No changes to commit" and exit.
 
+### Understanding chezmoi status/diff
+
+**Important**: When interpreting changes, remember:
+
+- `chezmoi status` shows files that differ between local and source
+- `chezmoi diff` shows what `chezmoi apply` would do:
+  - `-` lines = Current **local** content
+  - `+` lines = **Chezmoi source** content
+
+If local has changes not in source, `/chezmoi:commit` adds them to source.
+
 ### Step 2: Confirm with User
 
 Show the user which files will be committed:

--- a/plugins/chezmoi/commands/sync.md
+++ b/plugins/chezmoi/commands/sync.md
@@ -31,6 +31,28 @@ Updated files:
   - ...
 ```
 
+## Understanding chezmoi diff Output
+
+**Important**: `chezmoi diff` shows "what would happen if you run `chezmoi apply`".
+
+- `-` lines = Current **local** file content (destination)
+- `+` lines = **Chezmoi source** content (what would be applied)
+
+### Example
+
+```diff
+-    "plugin-x": true,
+-    "plugin-y": true
++    "plugin-x": true
+```
+
+**Interpretation**: Local has `plugin-y`, but chezmoi source does not.
+
+| Situation | Action |
+|-----------|--------|
+| Local has changes you want to keep | Run `/chezmoi:commit` to push to source |
+| Source has updates you want | Run `chezmoi apply` to apply to local |
+
 ## Error Handling
 
 ### Network Error


### PR DESCRIPTION
## Summary
- chezmoi diff 出力の解釈ガイドを追加
- sync.md と commit.md 両方にドキュメントを追加
- 差分解釈ミスを防止するための説明を記載

## Changes
| File | Description |
|------|-------------|
| `commit.md` | chezmoi status/diff の基本解釈（11行） |
| `sync.md` | 詳細な解釈ガイド + 例 + アクション表（22行） |

## Test plan
- [ ] ドキュメントの内容が技術的に正確か確認
- [ ] 両ファイル間で一貫性があるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)