### PR TITLE
fix(chezmoi): correct diff direction in commit command

### DIFF
--- a/plugins/chezmoi/commands/commit.md
+++ b/plugins/chezmoi/commands/commit.md
@@ -23,7 +23,7 @@ chezmoi status
 **Important: Understanding chezmoi status output**
 
 The `chezmoi status` output uses two columns (each single character):
-- **1st column**: Difference between chezmoi's recorded state and actual file (your local modifications)
+- **1st column**: Difference between chezmoi's recorded state and actual file (changes since last `chezmoi apply`)
 - **2nd column**: What `chezmoi apply` would change
 
 Common patterns:


### PR DESCRIPTION
## Summary

- chezmoi diffのデフォルト表示方向（repo → local）を`--reverse`フラグで逆転し、commit時に正しい方向（local → repo）で表示するよう修正
- diffの解釈ガイド（+ = ローカルで追加、- = ローカルで削除）を追加
- chezmoi statusのフラグ（RA, MM）の意味を説明

## Test plan

- [ ] `/chezmoi:commit`コマンドを実行し、diffが正しい方向で表示されることを確認
- [ ] `+`がローカルで追加した行、`-`がローカルで削除した行として表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)