### PR TITLE
fix(chezmoi): embed diff interpretation rules directly in commit skill

### DIFF
--- a/plugins/chezmoi/commands/commit.md
+++ b/plugins/chezmoi/commands/commit.md
@@ -39,8 +39,8 @@ chezmoi diff --reverse
 ```
 
 Report changes using standard git diff language:
-- "Will **add** X to source" (for `+` lines)
-- "Will **remove** X from source" (for `-` lines)
+- `-` lines: "Will **remove** X from source"
+- `+` lines: "Will **add** X to source"
 
 **Example:**
 ```diff

--- a/plugins/chezmoi/references/diff-interpretation.md
+++ b/plugins/chezmoi/references/diff-interpretation.md
@@ -20,9 +20,9 @@ This produces **git-like output** that shows what commit will do:
 
 ### Normal `chezmoi diff` (without flag)
 
-Shows what `chezmoi apply` would do (source → local):
-- `-` = content in LOCAL
-- `+` = content in SOURCE
+Shows what `chezmoi apply` would do (making local match source):
+- `-` = current content in LOCAL (destination)
+- `+` = desired content from SOURCE (target state)
 
 This is counterintuitive when committing (local → source).
 
@@ -57,6 +57,8 @@ Clear: Standard git diff semantics
 ---
 
 ## Reference: Normal Diff (Legacy)
+
+**Warning:** This section is for reference only. Always use `--reverse` for the commit workflow.
 
 If you must use `chezmoi diff` without `--reverse`:
 


### PR DESCRIPTION
## Summary

- `chezmoi diff` を `chezmoi diff --reverse` に変更
- git diffと同じ直感で読める出力に（`-` = 削除、`+` = 追加）
- 複雑な解釈ルール（禁止表現リスト、チェックリスト等）を削除してドキュメントを簡素化

## Test plan

- [ ] `/chezmoi:commit` を実行
- [ ] `chezmoi diff --reverse` が使用されることを確認
- [ ] `-` 行が「ソースから削除される」と報告される
- [ ] `+` 行が「ソースに追加される」と報告される

🤖 Generated with [Claude Code](https://claude.com/claude-code)