### PR TITLE
fix(code-review): resolve CLAUDE_PLUGIN_ROOT path issue

### DIFF
--- a/plugins/code-review/commands/review-commit.md
+++ b/plugins/code-review/commands/review-commit.md
@@ -28,6 +28,8 @@ Prompt: "Review the staged changes (git diff --cached) for this commit. Check fo
 
 **MANDATORY**: Run the approval script.
 
-Approve: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-review.sh`
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-review.sh
+```
 
 This saves a hash of the staged changes that the pre-commit hook verifies.


### PR DESCRIPTION
## Summary
- approve-review.shに自己解決ロジック（Hybrid Resolution Pattern）を追加
- review-commit.mdの`!`構文をcode block構文に変更
- CVIプラグインで実証済みのパターンを採用

## 背景
`/code:review-commit` スキル実行時に `${CLAUDE_PLUGIN_ROOT}` 環境変数が設定されず、スクリプトのパス解決に失敗する問題を修正。

## 変更内容
1. **approve-review.sh**: 3段階のフォールバックロジック追加
   - Priority 1: 環境変数 (hooks/code blocks)
   - Priority 2: BASH_SOURCE からスクリプト位置を逆算
   - Priority 3: プラグインキャッシュを検索

2. **review-commit.md**: `!` 構文を code block 構文に変更
   - 他プラグイン (gemini, kiro, codex, cvi, utils) と同じパターン

## Test plan
- [x] スクリプト単体動作確認: `bash plugins/code-review/scripts/approve-review.sh`
- [ ] プラグインキャッシュクリア後の統合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)