### PR TITLE
fix(code-review): use --staged instead of --cached

### DIFF
--- a/plugins/code-review/commands/review-commit.md
+++ b/plugins/code-review/commands/review-commit.md
@@ -17,7 +17,7 @@ If no staged changes, report "No staged changes to review" and exit.
 
 **MANDATORY**: Use Task tool with `pr-review-toolkit:code-reviewer` agent.
 
-Prompt: "Review the staged changes (git diff --cached) for this commit. Check for CLAUDE.md compliance, bugs, and code quality issues. Report only issues with confidence >= 80."
+Prompt: "Review the staged changes (git diff --staged) for this commit. Check for CLAUDE.md compliance, bugs, and code quality issues. Report only issues with confidence >= 80."
 
 ## Step 3: Handle Review Results
 


### PR DESCRIPTION
## Summary
- `!` バッククォート構文で `--cached` オプションが正しくパースされない問題を修正
- `git diff --cached` を `git diff --staged` に変更（同義語）
- コマンド実行部分とプロンプトテキストの両方を更新

## Changes
- `plugins/code-review/commands/review-commit.md`: Line 12, 20

## Test plan
- [ ] `/code:review-commit` コマンドを実行し、エラーが発生しないことを確認
- [ ] ステージされた変更が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)