### PR TITLE
fix(cvi): use ! syntax for immediate script execution

### DIFF
--- a/plugins/cvi/commands/speak.md
+++ b/plugins/cvi/commands/speak.md
@@ -6,23 +6,7 @@ description: Read text aloud using CVI settings
 
 テキストをCVI設定に従って読み上げます。
 
-以下のBashコマンドを**即座に実行**してください（確認ダイアログなし）:
+**実行結果**:
+!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak.sh $ARGUMENTS`
 
-```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak.sh $ARGUMENTS
-```
-
-## 引数
-
-- `<text>` - 読み上げるテキスト
-
-## 使用例
-
-- `/cvi:speak Hello World` - 「Hello World」を読み上げ
-- `/cvi:speak Task completed successfully` - タスク完了メッセージを読み上げ
-
-## 用途
-
-Stop hookのタイミング問題を回避するため、Claudeが直接音声通知をトリガーする際に使用します。
-
-実行後、結果を報告してください。
+上記の結果を確認し、音声通知が実行されたことをユーザーに伝えてください。


### PR DESCRIPTION
## Summary

- `/cvi:speak`コマンドでスクリプトが即時実行されない問題を修正
- `!`構文を使用して即時実行するように変更

## Problem

コマンド定義が「Bashコマンドを実行してください」と指示するだけで、Claudeが追加のBashツール呼び出しを行う必要があり、実際には実行されなかった。

## Solution

`!`構文を使用してスクリプトを即時実行:
```markdown
!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak.sh $ARGUMENTS`
```

## Test Plan

- [ ] `/cvi:speak`を呼び出して音声通知が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)