### PR TITLE
docs(cvi): clarify Skill tool usage for /cvi:speak

### DIFF
--- a/plugins/cvi/scripts/check-speak-called.sh
+++ b/plugins/cvi/scripts/check-speak-called.sh
@@ -76,5 +76,5 @@ else
 fi
 
 cat << EOF
-{"decision": "block", "reason": "MANDATORY: You must call /cvi:speak before stopping. This triggers voice notification for task completion. Call it now with your task summary. Example: /cvi:speak ${EXAMPLE_MSG}"}
+{"decision": "block", "reason": "MANDATORY: You must use the Skill tool to call /cvi:speak before stopping. Do NOT write '/cvi:speak' as text. Use Skill tool with skill='cvi:speak' and args='${EXAMPLE_MSG}' to trigger voice notification."}
 EOF

--- a/plugins/cvi/scripts/enforce-cvi-rules.sh
+++ b/plugins/cvi/scripts/enforce-cvi-rules.sh
@@ -39,7 +39,7 @@ cat << EOF
 ================================================
 ABSOLUTELY REQUIRED (NO EXCEPTIONS):
 1. [VOICE] tag: MUST use ${VOICE_LANG} (${VOICE_LANG_DISPLAY})
-2. /cvi:speak: MUST call after [VOICE] tag (triggers voice notification)
+2. /cvi:speak: MUST call using Skill tool (NOT as text)
 3. Response language: MUST use ${RESPONSE_LANG}
 
 🔴 MANDATORY TASK COMPLETION PATTERN:
@@ -47,7 +47,7 @@ ABSOLUTELY REQUIRED (NO EXCEPTIONS):
 
    [VOICE]<summary in 140 chars>[/VOICE]
 
-   /cvi:speak <same summary>
+   <use Skill tool: skill="cvi:speak" args="<same summary>">
 
 EOF
 
@@ -63,6 +63,7 @@ cat << EOF
    → Task completion summaries use ${VOICE_LANG_DISPLAY}
 
 3. /cvi:speak COMMAND: MANDATORY for voice notification
+   → Use Skill tool to call (NOT text "/cvi:speak")
    → Call AFTER writing [VOICE] tag
    → Use the SAME summary text as [VOICE] tag
    → This triggers: macOS notification + Glass sound + voice
@@ -93,7 +94,7 @@ cat << EOF
 ================================================
 BEFORE RESPONDING, VERIFY:
 □ [VOICE] tag language = ${VOICE_LANG} (${VOICE_LANG_DISPLAY})
-□ /cvi:speak called with same message as [VOICE] tag
+□ /cvi:speak called via Skill tool (NOT as text)
 □ Response language = ${RESPONSE_LANG}
 
 ⚠️ IF YOU FORGET /cvi:speak:

--- a/plugins/cvi/scripts/inject-cvi-context.sh
+++ b/plugins/cvi/scripts/inject-cvi-context.sh
@@ -67,15 +67,11 @@ cat << EOF
 
    [VOICE]<${VOICE_LANG_UPPER} summary in 140 chars>[/VOICE]
 
-   /cvi:speak <same ${VOICE_LANG_UPPER} summary>
+   <use Skill tool: skill="cvi:speak" args="<same summary>">
 
-   Example:
-   [VOICE]${VOICE_EXAMPLE}[/VOICE]
-
-   /cvi:speak ${VOICE_EXAMPLE}
-
-   ⚠️ Both [VOICE] tag AND /cvi:speak are REQUIRED
-   ⚠️ Stop hook will BLOCK if /cvi:speak not called
+   ⚠️ [VOICE] tag AND Skill tool call are REQUIRED
+   ⚠️ Do NOT write "/cvi:speak" as text - use Skill tool
+   ⚠️ Stop hook will BLOCK if /cvi:speak not called via Skill
 
    Exception: Questions to user (then no VOICE tag needed)
 EOF

--- a/plugins/cvi/skills/voice-integration/SKILL.md
+++ b/plugins/cvi/skills/voice-integration/SKILL.md
@@ -20,14 +20,18 @@ This skill provides guidance on using CVI (Claude Voice Integration) for voice n
 
 [VOICE]Brief summary in 140 chars or less[/VOICE]
 
-/cvi:speak Brief summary in 140 chars or less
+<use Skill tool: skill="cvi:speak" args="Brief summary">
 ```
 
-**Why both [VOICE] and /cvi:speak?**
-- `[VOICE]` tag: For display in the response (visible to user)
-- `/cvi:speak`: Triggers actual voice notification (macOS notification + Glass sound + voice)
+**CRITICAL: Use Skill tool, NOT text**
+- ❌ Do NOT write `/cvi:speak xxx` as text
+- ✅ Use Skill tool with `skill="cvi:speak"` and `args="your message"`
 
-**If you forget /cvi:speak:**
+**Why both [VOICE] and Skill tool call?**
+- `[VOICE]` tag: For display in the response (visible to user)
+- Skill tool `/cvi:speak`: Triggers actual voice notification (macOS notification + Glass sound + voice)
+
+**If you forget to use Skill tool:**
 - ❌ Stop hook will BLOCK your stop request
 - ❌ No voice notification will play
 - ❌ User will not hear task completion
@@ -116,15 +120,17 @@ When `ENGLISH_PRACTICE=on` in `~/.cvi/config`:
 
 ## Direct Voice Notification with /cvi:speak
 
-**For immediate voice notification**, use the `/cvi:speak` command after your [VOICE] tag:
+**For immediate voice notification**, use the Skill tool to call `/cvi:speak` after your [VOICE] tag:
 
 ```
 [detailed task explanation...]
 
 [VOICE]Brief summary[/VOICE]
 
-/cvi:speak Brief summary
+<use Skill tool: skill="cvi:speak" args="Brief summary">
 ```
+
+**CRITICAL**: Do NOT write `/cvi:speak` as text. You MUST use the Skill tool.
 
 This approach:
 - **Bypasses Stop hook timing issues**: Claude triggers voice directly
@@ -132,7 +138,7 @@ This approach:
 - **Uses CVI settings**: Language, voice, and speed settings are respected
 - **Includes all notifications**: macOS notification, Glass sound, and voice
 
-**Important**: The Stop hook will BLOCK if `/cvi:speak` is not called. This ensures voice notification is never forgotten.
+**Important**: The Stop hook will BLOCK if `/cvi:speak` is not called via Skill tool.
 
 ## What /cvi:speak Does
 


### PR DESCRIPTION
## Summary

- /cvi:speakはテキストではなくSkillツールで呼び出す必要があることを明確化

## Test Plan

- [ ] プラグイン更新後、再起動してテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)