### PR TITLE
perf(cvi): use direct say command for instant voice playback

### DIFF
--- a/plugins/cvi/scripts/speak.sh
+++ b/plugins/cvi/scripts/speak.sh
@@ -69,17 +69,6 @@ else
     fi
 fi
 
-# Generate audio
-TEMP_AUDIO="/tmp/cvi_speak_$$.aiff"
-
-if [ "$SELECTED_VOICE" = "system" ]; then
-    # Use system default (no -v flag)
-    say -r "$SPEECH_RATE" -o "$TEMP_AUDIO" "$MSG"
-else
-    # Use specific voice
-    say -v "$SELECTED_VOICE" -r "$SPEECH_RATE" -o "$TEMP_AUDIO" "$MSG"
-fi
-
 # Get current session directory name for notification
 SESSION_DIR=$(basename "$(pwd)")
 
@@ -87,9 +76,15 @@ SESSION_DIR=$(basename "$(pwd)")
 osascript -e "display notification \"$MSG\" with title \"ClaudeCode ($SESSION_DIR) Task Done\"" &
 
 # Play Glass sound to indicate completion
-afplay -v 1.0 /System/Library/Sounds/Glass.aiff &
+afplay /System/Library/Sounds/Glass.aiff &
 
-# Play voice audio in background and clean up
-(afplay -v 0.6 "$TEMP_AUDIO" && rm -f "$TEMP_AUDIO") &
+# Speak directly in background (no file generation delay)
+if [ "$SELECTED_VOICE" = "system" ]; then
+    # Use system default (no -v flag)
+    say -r "$SPEECH_RATE" "$MSG" &
+else
+    # Use specific voice
+    say -v "$SELECTED_VOICE" -r "$SPEECH_RATE" "$MSG" &
+fi
 
 echo "Speaking: $MSG"


### PR DESCRIPTION
## Summary
- `say -o` によるファイル生成を廃止
- `say` を直接バックグラウンドで実行
- レスポンス表示と音声再生の遅延を解消

## 背景
以前は音声ファイルを生成してから再生していたため、レスポンス表示後に音声が始まっていた。

## Test plan
- [ ] `/cvi:speak` 呼び出し時に即座に音声が再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)