### PR TITLE
fix(code): use repository-specific hash for commit approval files

### DIFF
--- a/plugins/code/scripts/approve-review.sh
+++ b/plugins/code/scripts/approve-review.sh
@@ -39,20 +39,14 @@ PLUGIN_ROOT=$(resolve_plugin_root) || {
     echo "Warning: Cannot determine plugin root (continuing anyway)" >&2
 }
 
-# Determine approval file location
-if [[ -d ".claude" ]]; then
-    if [[ ! -w ".claude" ]]; then
-        echo "Error: .claude directory exists but is not writable" >&2
-        exit 1
-    fi
-    REVIEW_FILE=".claude/review-approved"
-else
-    if ! mkdir -p /tmp/claude; then
-        echo "Failed to create /tmp/claude directory" >&2
-        exit 1
-    fi
-    REVIEW_FILE="/tmp/claude/review-approved"
+# Get repository root and create unique approval file per repository
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")
+REPO_HASH=$(echo "$REPO_ROOT" | shasum -a 256 | cut -c1-16)
+if ! mkdir -p /tmp/claude; then
+    echo "Failed to create /tmp/claude directory" >&2
+    exit 1
 fi
+REVIEW_FILE="/tmp/claude/review-approved-${REPO_HASH}"
 
 # Get staged changes hash
 GIT_OUTPUT=$(git diff --cached --raw 2>&1)

--- a/plugins/code/scripts/check-code-review.sh
+++ b/plugins/code/scripts/check-code-review.sh
@@ -16,12 +16,11 @@ fi
 
 # Check if this is a git commit command
 if [[ "$COMMAND" =~ ^git[[:space:]]+commit ]] || [[ "$COMMAND" =~ git[[:space:]]+commit ]]; then
-    # Use project-local .claude directory or /tmp/claude as fallback
-    if [[ -d ".claude" ]]; then
-        REVIEW_FILE=".claude/review-approved"
-    else
-        REVIEW_FILE="/tmp/claude/review-approved"
-    fi
+    # Get repository root and create unique approval file per repository
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")
+    REPO_HASH=$(echo "$REPO_ROOT" | shasum -a 256 | cut -c1-16)
+    mkdir -p /tmp/claude 2>/dev/null
+    REVIEW_FILE="/tmp/claude/review-approved-${REPO_HASH}"
 
     # Check if review approval file exists
     if [[ -f "$REVIEW_FILE" ]]; then


### PR DESCRIPTION
## Summary

- 異なるリポジトリ間で`/code:review-commit`承認後のコミットがブロックされる問題を修正
- `.claude`ディレクトリの有無による条件分岐を削除し、リポジトリ固有のハッシュを使用
- 承認ファイルパス: `/tmp/claude/review-approved-<repo-hash>`

## 根本原因

| スクリプト | 実行コンテキスト | `.claude`の有無 | 使用パス |
|-----------|-----------------|----------------|----------|
| `approve-review.sh` | ターゲットリポジトリ | なし | `/tmp/claude/review-approved` |
| `check-code-review.sh` | Claude Codeプロジェクト | あり | `.claude/review-approved` |

承認と検証で参照するファイルが一致しないため、他リポジトリでのコミットがブロックされていた。

## 解決策

リポジトリルートパスのSHA256ハッシュ（16文字）を使用して一貫したパスを生成:
```bash
REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")
REPO_HASH=$(echo "$REPO_ROOT" | shasum -a 256 | cut -c1-16)
REVIEW_FILE="/tmp/claude/review-approved-${REPO_HASH}"
```

## Test plan

- [ ] claude-tools内でレビュー承認後、コミット成功
- [ ] chezmoi等でレビュー承認後、コミット成功
- [ ] 承認後にステージ変更を追加 → コミットブロック（期待動作）

🤖 Generated with [Claude Code](https://claude.ai/code)