### PR TITLE
fix(code): parse cd directory and skip gh commands in hook

### DIFF
--- a/plugins/code/scripts/check-code-review.sh
+++ b/plugins/code/scripts/check-code-review.sh
@@ -14,18 +14,39 @@ else
     COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 fi
 
-# Check if this is a git commit command
-if [[ "$COMMAND" =~ ^git[[:space:]]+commit ]] || [[ "$COMMAND" =~ git[[:space:]]+commit ]]; then
-    # Get repository root and create unique approval file per repository
-    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")
+# Skip gh commands (they may contain "git commit" in PR body text)
+if [[ "$COMMAND" =~ ^gh[[:space:]] ]]; then
+    exit 0
+fi
+
+# Check if this is a git commit command (at start or after "cd ... &&")
+if [[ "$COMMAND" =~ ^git[[:space:]]+commit ]] || [[ "$COMMAND" =~ \&\&[[:space:]]*git[[:space:]]+commit ]]; then
+    # Extract target directory if command contains "cd <path> &&"
+    TARGET_DIR=""
+    if [[ "$COMMAND" =~ ^cd[[:space:]]+([^[:space:]&]+)[[:space:]]*\&\& ]]; then
+        TARGET_DIR="${BASH_REMATCH[1]}"
+        # Expand ~ to home directory
+        TARGET_DIR="${TARGET_DIR/#\~/$HOME}"
+    fi
+
+    # Get repository root from target directory or current directory
+    if [[ -n "$TARGET_DIR" && -d "$TARGET_DIR" ]]; then
+        REPO_ROOT=$(cd "$TARGET_DIR" && git rev-parse --show-toplevel 2>/dev/null || echo "unknown")
+    else
+        REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")
+    fi
     REPO_HASH=$(echo "$REPO_ROOT" | shasum -a 256 | cut -c1-16)
     mkdir -p /tmp/claude 2>/dev/null
     REVIEW_FILE="/tmp/claude/review-approved-${REPO_HASH}"
 
     # Check if review approval file exists
     if [[ -f "$REVIEW_FILE" ]]; then
-        # Get current staged changes hash
-        CURRENT_HASH=$(git diff --cached --raw 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+        # Get current staged changes hash from target directory
+        if [[ -n "$TARGET_DIR" && -d "$TARGET_DIR" ]]; then
+            CURRENT_HASH=$(cd "$TARGET_DIR" && git diff --cached --raw 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+        else
+            CURRENT_HASH=$(git diff --cached --raw 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+        fi
         APPROVED_HASH=$(cat "$REVIEW_FILE" 2>/dev/null)
 
         if [[ "$CURRENT_HASH" == "$APPROVED_HASH" ]]; then


### PR DESCRIPTION
## Summary

hookの2つの問題を修正：

1. **cd解析**: コマンド内の「cd <path> &&」パターンを解析し、ターゲットディレクトリのリポジトリハッシュを使用
2. **ghスキップ**: ghコマンドを早期スキップして、PR本文中の文字列への誤反応を防止
3. **厳密マッチ**: git操作のマッチを行頭または「&&」後のみに限定

## 背景

PR #75でリポジトリ固有ハッシュを導入したが、以下の問題が残っていた：
- `cd ~/.local/share/chezmoi && git ...`でhookが誤ったディレクトリを参照
- `gh pr create --body "..."`でPR本文中の文字列に誤反応

## Test plan

- [ ] claude-toolsで通常のコミット → 動作確認
- [ ] chezmoi等で cd && コミット → 承認後成功  
- [ ] gh pr create with "git ..." in body → ブロックされない

🤖 Generated with [Claude Code](https://claude.ai/code)