### PR TITLE
fix(cvi): add explicit Voice display format to speak command

### DIFF
--- a/plugins/cvi/commands/speak.md
+++ b/plugins/cvi/commands/speak.md
@@ -9,4 +9,8 @@ description: Read text aloud using CVI settings
 **実行結果**:
 !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak.sh $ARGUMENTS`
 
-上記の結果を確認し、音声通知が実行されたことをユーザーに伝えてください。
+上記の結果を確認し、以下の形式でユーザーに表示してください（絵文字不可）:
+
+```
+Voice: "読み上げたテキスト"
+```


### PR DESCRIPTION
## Summary

- speak.md実行後に「Voice: "テキスト"」形式で明示的に表示するよう指示を追加
- UIにスクリプト出力が表示されない問題への対応
- 絵文字使用不可を明記

## Test plan

- [ ] /cvi:speak実行後にVoice形式で表示される

---
Generated with Claude Code