### PR TITLE
fix(cvi): add plan mode compatibility for /cvi:speak requirement

### DIFF
--- a/plugins/cvi/scripts/enforce-cvi-rules.sh
+++ b/plugins/cvi/scripts/enforce-cvi-rules.sh
@@ -111,6 +111,10 @@ BEFORE RESPONDING, VERIFY:
 → Voice notification will NOT play until you call it
 
 ⚠️ NO [VOICE] TAG - use Skill tool only
+
+⚠️ PLAN MODE: /cvi:speak is STILL REQUIRED even in plan mode
+→ Skill tool works in plan mode - use it
+→ Do NOT skip or apologize for voice notification
 ================================================
 EOF
 

--- a/plugins/cvi/scripts/inject-cvi-context.sh
+++ b/plugins/cvi/scripts/inject-cvi-context.sh
@@ -73,6 +73,7 @@ cat << EOF
    ⚠️ Stop hook will BLOCK if /cvi:speak not called via Skill
 
    Exception: Questions to user (then no notification needed)
+   ⚠️ Plan mode is NOT an exception - /cvi:speak is STILL required
 EOF
 
 exit 0


### PR DESCRIPTION
## Summary

- Planモード中にClaudeが`/cvi:speak`をスキップする問題を修正
- `enforce-cvi-rules.sh`のBOTTOM SLICEにPlanモードでも必須と明示
- `inject-cvi-context.sh`にPlanモードは例外ではないと明示

## 根本原因

hookメッセージに「Planモードでも/cvi:speakは必須」という明示がなかったため、Claudeが自己判断でスキップし「Planモードのため音声通知はスキップされました」という謝罪メッセージを生成していた。

## Test plan

- [ ] Claude Code再起動
- [ ] Planモードに入る
- [ ] タスク完了時に/cvi:speakが呼び出されることを確認
- [ ] 「スキップされました」が表示されないことを確認
- [ ] Stop hookが/cvi:speak未呼び出し時にブロックすることを確認
- [ ] 通常モードの動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)