### PR TITLE
feat(plugins): add settings.json and fix author name consistency

### DIFF
--- a/plugins/chezmoi/.claude-plugin/plugin.json
+++ b/plugins/chezmoi/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "chezmoi",
   "description": "Dotfiles management integration for Claude Code using chezmoi",
   "author": {
-    "name": "SignalCompose",
+    "name": "Signal compose",
     "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "code",
   "description": "Code review workflow integration for git commits",
   "author": {
-    "name": "SignalCompose",
+    "name": "Signal compose",
     "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "codex",
   "description": "OpenAI Codex CLI integration for research and code review",
   "author": {
-    "name": "SignalCompose",
+    "name": "Signal compose",
     "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",

--- a/plugins/codex/.claude/settings.json
+++ b/plugins/codex/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
+    ]
+  }
+}

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "gemini",
   "description": "Google Gemini CLI integration for web search",
   "author": {
-    "name": "SignalCompose",
+    "name": "Signal compose",
     "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",

--- a/plugins/gemini/.claude/settings.json
+++ b/plugins/gemini/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
+    ]
+  }
+}

--- a/plugins/kiro/.claude-plugin/plugin.json
+++ b/plugins/kiro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "kiro",
   "description": "AWS Kiro CLI integration for research and troubleshooting",
   "author": {
-    "name": "SignalCompose",
+    "name": "Signal compose",
     "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",

--- a/plugins/kiro/.claude/settings.json
+++ b/plugins/kiro/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
+    ]
+  }
+}

--- a/plugins/utils/.claude-plugin/plugin.json
+++ b/plugins/utils/.claude-plugin/plugin.json
@@ -2,7 +2,8 @@
   "name": "utils",
   "description": "Utility commands for Claude Code plugin management",
   "author": {
-    "name": "SignalCompose"
+    "name": "Signal compose",
+    "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",
   "license": "MIT",

--- a/plugins/utils/.claude/settings.json
+++ b/plugins/utils/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
+    ],
+    "deny": [
+      "Bash(rm -rf ~/*)",
+      "Bash(rm -rf /*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- codex, gemini, kiro, utils に settings.json を追加
- 全6プラグインの author.name を Signal compose に統一
- utils の plugin.json に author.email を追加

## Test plan
- [ ] jq . で各 settings.json の構文検証
- [ ] 各 plugin.json の author.name 確認

Generated with Claude Code