### PR TITLE
fix(cvi): use queue-based architecture for sandbox-compatible speech

### DIFF
--- a/plugins/cvi/hooks/hooks.json
+++ b/plugins/cvi/hooks/hooks.json
@@ -42,6 +42,18 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak-from-queue.sh",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "",

--- a/plugins/cvi/scripts/speak-from-queue.sh
+++ b/plugins/cvi/scripts/speak-from-queue.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# CVI Speak From Queue - PostToolUse hook handler
+# Runs outside sandbox, reads queue file and plays audio.
+# Called by PostToolUse hook with matcher="Skill".
+# Filters on skill="cvi:speak"; exits immediately for other skills.
+
+# Extract skill name from stdin (use jq if available, fallback to regex)
+INPUT=$(cat)
+if command -v jq &> /dev/null; then
+    SKILL_NAME=$(echo "$INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null)
+fi
+# Fallback: regex extraction if jq unavailable or returned empty
+if [ -z "$SKILL_NAME" ]; then
+    SKILL_NAME=$(echo "$INPUT" | grep -o '"skill"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"skill"[[:space:]]*:[[:space:]]*"//' | sed 's/"//')
+fi
+
+# Only process cvi:speak
+[ "$SKILL_NAME" != "cvi:speak" ] && exit 0
+
+# Claim queue file via rename to prevent read/write overlap with speak.sh
+QUEUE_FILE="$HOME/.cvi/speak-queue"
+TEMP_QUEUE="${QUEUE_FILE}.$$"
+
+# No queue file = nothing to speak (e.g. CVI disabled or write failed)
+[ ! -f "$QUEUE_FILE" ] && exit 0
+
+# Queue file exists - attempt atomic claim
+if ! mv "$QUEUE_FILE" "$TEMP_QUEUE" 2>/dev/null; then
+    echo "Error: Failed to claim queue file $QUEUE_FILE" >&2
+    exit 1
+fi
+
+if ! MSG=$(cat "$TEMP_QUEUE" 2>/dev/null); then
+    echo "Error: Failed to read temp queue file $TEMP_QUEUE" >&2
+    rm -f "$TEMP_QUEUE"
+    exit 1
+fi
+rm -f "$TEMP_QUEUE" || echo "Warning: Failed to clean up $TEMP_QUEUE" >&2
+[ -z "$MSG" ] && exit 0
+
+# Load CVI config
+CONFIG_FILE="$HOME/.cvi/config"
+if [ -f "$CONFIG_FILE" ]; then
+    SPEECH_RATE=$(grep "^SPEECH_RATE=" "$CONFIG_FILE" | cut -d'=' -f2)
+    VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
+    VOICE_EN=$(grep "^VOICE_EN=" "$CONFIG_FILE" | cut -d'=' -f2)
+    VOICE_JA=$(grep "^VOICE_JA=" "$CONFIG_FILE" | cut -d'=' -f2)
+    AUTO_DETECT_LANG=$(grep "^AUTO_DETECT_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
+    VOICE_MODE=$(grep "^VOICE_MODE=" "$CONFIG_FILE" | cut -d'=' -f2)
+    VOICE_FIXED=$(grep "^VOICE_FIXED=" "$CONFIG_FILE" | cut -d'=' -f2)
+fi
+
+SPEECH_RATE=${SPEECH_RATE:-200}
+VOICE_LANG=${VOICE_LANG:-ja}
+VOICE_EN=${VOICE_EN:-Samantha}
+VOICE_JA=${VOICE_JA:-system}
+AUTO_DETECT_LANG=${AUTO_DETECT_LANG:-false}
+VOICE_MODE=${VOICE_MODE:-auto}
+
+# Validate SPEECH_RATE is numeric
+if ! [[ "$SPEECH_RATE" =~ ^[0-9]+$ ]]; then
+    echo "Warning: Invalid SPEECH_RATE='$SPEECH_RATE' in config, using default 200" >&2
+    SPEECH_RATE=200
+fi
+
+# Detect language if AUTO_DETECT_LANG is enabled, otherwise use configured VOICE_LANG
+if [ "$AUTO_DETECT_LANG" = "true" ]; then
+    if echo "$MSG" | grep -q '[ぁ-んァ-ヶー一-龠]'; then
+        DETECTED_LANG="ja"
+    else
+        DETECTED_LANG="en"
+    fi
+else
+    DETECTED_LANG="$VOICE_LANG"
+fi
+
+# Select voice based on mode and detected language
+if [ "$VOICE_MODE" = "fixed" ] && [ -n "$VOICE_FIXED" ]; then
+    SELECTED_VOICE="$VOICE_FIXED"
+elif [ "$DETECTED_LANG" = "ja" ]; then
+    SELECTED_VOICE="$VOICE_JA"
+else
+    SELECTED_VOICE="$VOICE_EN"
+fi
+
+# Sanitize message (escape backslashes, double quotes, and replace newlines with spaces)
+SAFE_MSG=$(printf '%s' "$MSG" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')
+
+# Execute audio (runs outside sandbox, so osascript/afplay/say are not blocked)
+SESSION_DIR=$(basename "$(pwd)")
+osascript -e "display notification \"$SAFE_MSG\" with title \"ClaudeCode ($SESSION_DIR) Task Done\"" 2>/dev/null &
+afplay /System/Library/Sounds/Glass.aiff 2>/dev/null &
+if [ "$SELECTED_VOICE" = "system" ]; then
+    say -r "$SPEECH_RATE" -- "$SAFE_MSG" 2>/dev/null &
+else
+    say -v "$SELECTED_VOICE" -r "$SPEECH_RATE" -- "$SAFE_MSG" 2>/dev/null &
+fi
+SAY_PID=$!
+
+# Wait for say to finish and check for errors (say is the critical command)
+wait "$SAY_PID" 2>/dev/null
+SAY_EXIT=$?
+if [ $SAY_EXIT -ne 0 ]; then
+    echo "Warning: say command failed (exit $SAY_EXIT), voice='${SELECTED_VOICE}', rate='${SPEECH_RATE}'" >&2
+fi

--- a/plugins/cvi/scripts/speak.sh
+++ b/plugins/cvi/scripts/speak.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# CVI Speak Script
-# Read provided text aloud using CVI settings
+# CVI Speak Script - Queue-based (sandbox-compatible)
+# Writes message to queue file instead of directly playing audio.
+# Audio playback is handled by PostToolUse hook (speak-from-queue.sh)
+# which runs outside the sandbox.
 
 # Get the text to speak from arguments
 MSG="$*"
@@ -25,66 +27,16 @@ if [ "$CVI_ENABLED" = "off" ]; then
     exit 0
 fi
 
-# Load configuration from file
-if [ -f "$CONFIG_FILE" ]; then
-    SPEECH_RATE=$(grep "^SPEECH_RATE=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_EN=$(grep "^VOICE_EN=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_JA=$(grep "^VOICE_JA=" "$CONFIG_FILE" | cut -d'=' -f2)
-    AUTO_DETECT_LANG=$(grep "^AUTO_DETECT_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_MODE=$(grep "^VOICE_MODE=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_FIXED=$(grep "^VOICE_FIXED=" "$CONFIG_FILE" | cut -d'=' -f2)
+# Ensure ~/.cvi/ directory exists
+if ! mkdir -p "$HOME/.cvi" 2>/dev/null; then
+    echo "Error: Failed to create directory $HOME/.cvi" >&2
+    exit 1
 fi
 
-# Set defaults
-SPEECH_RATE=${SPEECH_RATE:-200}
-VOICE_LANG=${VOICE_LANG:-ja}
-VOICE_EN=${VOICE_EN:-Samantha}
-VOICE_JA=${VOICE_JA:-system}
-AUTO_DETECT_LANG=${AUTO_DETECT_LANG:-false}
-VOICE_MODE=${VOICE_MODE:-auto}
-
-# Detect language if AUTO_DETECT_LANG is enabled
-if [ "$AUTO_DETECT_LANG" = "true" ]; then
-    if echo "$MSG" | grep -q '[ぁ-んァ-ヶー一-龠]'; then
-        DETECTED_LANG="ja"
-    else
-        DETECTED_LANG="en"
-    fi
-else
-    # Use configured language
-    DETECTED_LANG="$VOICE_LANG"
-fi
-
-# Select voice based on mode and detected language
-if [ "$VOICE_MODE" = "fixed" ] && [ -n "$VOICE_FIXED" ]; then
-    # Fixed mode: use specified voice for all languages
-    SELECTED_VOICE="$VOICE_FIXED"
-else
-    # Auto mode: select voice based on detected language
-    if [ "$DETECTED_LANG" = "ja" ]; then
-        SELECTED_VOICE="$VOICE_JA"
-    else
-        SELECTED_VOICE="$VOICE_EN"
-    fi
-fi
-
-# Get current session directory name for notification
-SESSION_DIR=$(basename "$(pwd)")
-
-# Display macOS notification
-osascript -e "display notification \"$MSG\" with title \"ClaudeCode ($SESSION_DIR) Task Done\"" &
-
-# Play Glass sound to indicate completion
-afplay /System/Library/Sounds/Glass.aiff &
-
-# Speak directly in background (no file generation delay)
-if [ "$SELECTED_VOICE" = "system" ]; then
-    # Use system default (no -v flag)
-    say -r "$SPEECH_RATE" "$MSG" &
-else
-    # Use specific voice
-    say -v "$SELECTED_VOICE" -r "$SPEECH_RATE" "$MSG" &
+# Write message to queue file (sandbox allows ~/.cvi/ writes per plugin permissions)
+if ! echo "$MSG" > "$HOME/.cvi/speak-queue" 2>/dev/null; then
+    echo "Error: Failed to write to ~/.cvi/speak-queue" >&2
+    exit 1
 fi
 
 echo "Speaking: $MSG"


### PR DESCRIPTION
## Summary

- サンドボックス内で `say`/`afplay`/`osascript` がブロックされ音声が鳴らない問題を修正
- キューファイルベースのアーキテクチャに変更: `speak.sh`（サンドボックス内）はキューファイルへの書き込みのみ、PostToolUse フック（サンドボックス外）が音声再生を担当
- osascript へのコマンドインジェクション対策とキューファイルの atomic 操作を追加

## Architecture

```
[Skill tool: cvi:speak]
  → speak.sh (sandbox内) → ~/.cvi/speak-queue に書き込み

[PostToolUse hook: matcher="Skill"]
  → speak-from-queue.sh (sandbox外) → キュー読み取り → 音声再生
```

## Changed Files

| File | Change |
|------|--------|
| `plugins/cvi/scripts/speak.sh` | 音声再生コード削除、キューファイル書き込みのみに |
| `plugins/cvi/scripts/speak-from-queue.sh` | 新規: PostToolUseフックハンドラ |
| `plugins/cvi/hooks/hooks.json` | PostToolUse フック追加 |

## Test plan

- [ ] サンドボックス有効の状態で `/cvi:speak` 実行 → 音声・通知・効果音が鳴ること
- [ ] サンドボックス無効の状態でも同様に動作すること
- [ ] `check-speak-called.sh`（Stop フック）が引き続き機能すること
- [ ] CVI無効時（`/cvi:state off`）にキューファイルが作成されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)