### PR TITLE
fix(chezmoi): resolve command palette duplicates

### DIFF
--- a/plugins/chezmoi/skills/chezmoi-commit/SKILL.md
+++ b/plugins/chezmoi/skills/chezmoi-commit/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Commit and push changed dotfiles to remote repository.
   Use when: "commit dotfiles", "push dotfiles", "save dotfile changes",
   "dotfilesコミット", "dotfiles反映".
-user-invocable: true
+user-invocable: false
 ---
 
 # Chezmoi Commit

--- a/plugins/chezmoi/skills/chezmoi-setup/SKILL.md
+++ b/plugins/chezmoi/skills/chezmoi-setup/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Interactive setup wizard for chezmoi dotfiles management with age encryption and 1Password integration.
   Use when: "set up chezmoi", "configure dotfiles", "initialize chezmoi",
   "chezmoi初期設定", "dotfiles設定", "1Password連携".
-user-invocable: true
+user-invocable: false
 ---
 
 # Chezmoi Setup Wizard

--- a/plugins/chezmoi/skills/shell-sync-setup/SKILL.md
+++ b/plugins/chezmoi/skills/shell-sync-setup/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Install shell startup sync checker for chezmoi dotfiles.
   Use when: "set up shell sync", "install chezmoi checker",
   "シェル同期チェッカー設定", "起動時チェック設定".
-user-invocable: true
+user-invocable: false
 ---
 
 # Chezmoi Shell Sync Checker Setup


### PR DESCRIPTION
## Summary

chezmoiプラグインのコマンドパレットで同じ機能が2回表示される問題を修正。

## Changes

- `plugins/chezmoi/skills/chezmoi-commit/SKILL.md`: `user-invocable: true` → `false`
- `plugins/chezmoi/skills/chezmoi-setup/SKILL.md`: `user-invocable: true` → `false`
- `plugins/chezmoi/skills/shell-sync-setup/SKILL.md`: `user-invocable: true` → `false`

### 原因

コマンド（スタブ）とスキルの両方が `user-invocable` のためパレットに表示されていた:
- `/chezmoi:commit` (コマンド) と `/chezmoi:chezmoi-commit` (スキル)
- `/chezmoi:setup` (コマンド) と `/chezmoi:chezmoi-setup` (スキル)
- `/chezmoi:setup-shell-check` (コマンド) と `/chezmoi:shell-sync-setup` (スキル)

### 修正方針

スキル側の `user-invocable` を `false` に変更。コマンド（スタブ）が唯一の入口となり、Progressive Disclosure 構造を維持。

## Checklist

- [x] ドキュメントを更新した（該当する場合）
- [ ] marketplace.jsonを更新した（プラグイン追加/変更時） N/A
- [ ] Subtreeが正しく設定されている（プラグイン追加時） N/A

## Related Issues

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)