### PR TITLE
fix(chezmoi): restore user-invocable flag for 3 skills

### DIFF
--- a/plugins/chezmoi/skills/commit/SKILL.md
+++ b/plugins/chezmoi/skills/commit/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Commit and push changed dotfiles to remote repository.
   Use when: "commit dotfiles", "push dotfiles", "save dotfile changes",
   "dotfilesコミット", "dotfiles反映".
-user-invocable: false
+user-invocable: true
 ---
 
 # Chezmoi Commit

--- a/plugins/chezmoi/skills/setup/SKILL.md
+++ b/plugins/chezmoi/skills/setup/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Interactive setup wizard for chezmoi dotfiles management with age encryption and 1Password integration.
   Use when: "set up chezmoi", "configure dotfiles", "initialize chezmoi",
   "chezmoi初期設定", "dotfiles設定", "1Password連携".
-user-invocable: false
+user-invocable: true
 ---
 
 # Chezmoi Setup Wizard

--- a/plugins/chezmoi/skills/shell-sync-setup/SKILL.md
+++ b/plugins/chezmoi/skills/shell-sync-setup/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Install shell startup sync checker for chezmoi dotfiles.
   Use when: "set up shell sync", "install chezmoi checker",
   "シェル同期チェッカー設定", "起動時チェック設定".
-user-invocable: false
+user-invocable: true
 ---
 
 # Chezmoi Shell Sync Checker Setup


### PR DESCRIPTION
## Summary
- PR #87 マージ時に PR #86 の user-invocable: false が Git 自動マージで取り込まれ、setup / commit / shell-sync-setup の3スキルがスラッシュコマンド候補から消えていた
- 3ファイルの user-invocable フラグを true に復元

## Changes
| File | Change |
|------|--------|
| plugins/chezmoi/skills/setup/SKILL.md | user-invocable: false → true |
| plugins/chezmoi/skills/commit/SKILL.md | user-invocable: false → true |
| plugins/chezmoi/skills/shell-sync-setup/SKILL.md | user-invocable: false → true |

## Test plan
- [ ] /chez 入力時に 5 スキル全て（check, sync, setup, commit, shell-sync-setup）が候補に表示されること
- [ ] マージ後に /utils:clear-plugin-cache chezmoi で反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)