### PR TITLE
Fix /code:review-commit command frontmatter

### DIFF
--- a/plugins/code/commands/review-commit.md
+++ b/plugins/code/commands/review-commit.md
@@ -1,3 +1,7 @@
+---
+description: Review working directory changes for code quality, security, and best practices before committing
+---
+
 # Code Review for Commit
 
 ステージング済み変更をレビューし、コミット前にすべてのcritical/important問題を修正。


### PR DESCRIPTION
## 概要

`/code:review-commit` コマンドに欠けていた frontmatter を追加し、コマンド実行時にスキルワークフローが自動的に開始されるように修正しました。

## 変更内容

- `plugins/code/commands/review-commit.md` に `description` フィールドを含む frontmatter を追加
- コマンドとスキルの自動リンクを有効化

## 修正前の動作

- `/code:review-commit` 実行 → ドキュメントが表示されるだけ
- スキルワークフロー（チーム作成、レビューループなど）が開始されない

## 修正後の期待動作

- `/code:review-commit` 実行 → スキルワークフローが自動的に開始
- レビューチーム作成、反復的なレビューループ、承認フラグ作成が実行される

## テスト計画

1. PR マージ後、マーケットプレイス更新（`/plugin update`）
2. プラグインキャッシュクリア（`/utils:clear-plugin-cache code`）
3. Claude Code 再起動
4. `/code:review-commit` コマンドを実行して動作確認