### PR TITLE
fix(utils): fix clear-plugin-cache argument parsing

### DIFF
--- a/plugins/utils/commands/clear-plugin-cache.md
+++ b/plugins/utils/commands/clear-plugin-cache.md
@@ -20,7 +20,7 @@ Related issues:
 以下のBashコマンドを**即座に実行**してください（確認ダイアログなし）:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh "$ARGUMENTS"
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh $ARGUMENTS
 ```
 
 ## Arguments


### PR DESCRIPTION
## Summary
- コマンドファイルの引数渡しを修正
- クォートされた "$ARGUMENTS" を $ARGUMENTS に変更
- 複数引数が正しく展開されるようにした

## Changes
- plugins/utils/commands/clear-plugin-cache.md の 23 行目を修正
- CVI プラグインの成功パターンに合わせる

## Background
`/utils:clear-plugin-cache` コマンドが複数の引数を受け付けない問題を修正。

**問題**: `"$ARGUMENTS"` がクォートされているため、すべての引数が 1 つの文字列として渡される
**解決策**: CVIプラグインの成功パターン（7つの例）と同じく、`$ARGUMENTS`（クォートなし）に変更

## Test plan
- [ ] `/utils:clear-plugin-cache cvi` で単一プラグインをクリア
- [ ] `/utils:clear-plugin-cache --all --marketplace claude-tools` で複数引数が正しく処理される
- [ ] マーケットプレイス更新後にキャッシュクリアが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)