### PR TITLE
fix(cvi): improve speak command security and reliability

### DIFF
--- a/plugins/cvi/commands/speak.md
+++ b/plugins/cvi/commands/speak.md
@@ -8,7 +8,7 @@ user-invocable: false
 テキストをCVI設定に従って読み上げます。
 
 **実行結果**:
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak.sh "$ARGUMENTS" > /dev/null 2>&1 &`
+!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/speak-sync.sh "$ARGUMENTS"`
 
 上記の結果を確認し、以下の形式でユーザーに表示してください（絵文字不可）:
 


### PR DESCRIPTION
## 概要

CVIプラグインのspeakコマンドをspeak-sync.shに移行し、セキュリティと信頼性を強化しました。

## 変更内容

### speak.md
- speak-sync.shを使用するように変更
- エラー出力の隠蔽を解除
- バックグラウンド実行を削除

### speak-sync.sh & speak.sh
- コマンドインジェクション脆弱性を修正（osascript argv使用）
- エラーハンドリングを一貫化（set -euo pipefail追加）
- 設定検証を追加（空文字列対応）
- エラーログ機能を追加（~/.cvi/error.log）

## 理由
- セキュリティ: コマンドインジェクション防止
- 信頼性: エラーハンドリングの一貫性
- デバッグ性: エラー出力とログ記録
- 堅牢性: 設定ミスによる誤動作防止

## テスト計画

- [ ] マーケットプレイス更新（`/plugin update`）
- [ ] キャッシュクリア（`/utils:clear-plugin-cache cvi`）
- [ ] Claude Code再起動
- [ ] `/cvi:speak`コマンド動作確認
- [ ] エラーログ記録確認（`~/.cvi/error.log`）

## 影響
- /cvi:speakコマンドがより安全で堅牢になる
- エラーが適切にログ記録される
- AudioQueueエラーが見えるようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)