### PR TITLE
fix(skills): migrate Progressive Disclosure to Claude Code standard pattern

### DIFF
--- a/plugins/chezmoi/skills/commit/SKILL.md
+++ b/plugins/chezmoi/skills/commit/SKILL.md
@@ -15,7 +15,7 @@ Detect changed dotfiles, commit and push to remote.
 
 Use `chezmoi diff --reverse` to get git-like diff output. Read it exactly like a normal `git diff`.
 
-For detailed examples, see [references/diff-interpretation.md](references/diff-interpretation.md).
+For detailed examples, read `${CLAUDE_PLUGIN_ROOT}/skills/commit/references/diff-interpretation.md`.
 
 ## Execution
 
@@ -31,7 +31,7 @@ Present detected changes and ask for confirmation before proceeding.
 
 Add files with `chezmoi add`, then commit and push from `~/.local/share/chezmoi`.
 
-For detailed execution steps and error handling, see [references/commit-workflow.md](references/commit-workflow.md).
+For detailed execution steps and error handling, read `${CLAUDE_PLUGIN_ROOT}/skills/commit/references/commit-workflow.md`.
 
 ## Flow
 

--- a/plugins/chezmoi/skills/setup/SKILL.md
+++ b/plugins/chezmoi/skills/setup/SKILL.md
@@ -24,22 +24,22 @@ This wizard guides through 5 phases:
 
 ### Phase 1: Environment Check
 
-See [references/phase-1-environment.md](references/phase-1-environment.md) for tool detection steps.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/phase-1-environment.md` for tool detection steps.
 
 ### Phase 2: Detect Existing Setup
 
-See [references/phase-2-detect-existing.md](references/phase-2-detect-existing.md) for existing configuration detection.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/phase-2-detect-existing.md` for existing configuration detection.
 
 ### Phase 3: Mode Selection
 
-See [references/phase-3-mode-selection.md](references/phase-3-mode-selection.md) for setup mode options.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/phase-3-mode-selection.md` for setup mode options.
 
 ### Phase 4: Setup Guide
 
 Based on selection:
-- **New setup (first machine)**: See [references/phase-4a-new-setup.md](references/phase-4a-new-setup.md)
-- **Clone existing (second+ machine)**: See [references/phase-4b-clone-existing.md](references/phase-4b-clone-existing.md)
+- **New setup (first machine)**: Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/phase-4a-new-setup.md`
+- **Clone existing (second+ machine)**: Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/phase-4b-clone-existing.md`
 
 ### Phase 5: Verification
 
-See [references/phase-5-verification.md](references/phase-5-verification.md) for post-setup verification.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/phase-5-verification.md` for post-setup verification.

--- a/plugins/chezmoi/skills/shell-sync-setup/SKILL.md
+++ b/plugins/chezmoi/skills/shell-sync-setup/SKILL.md
@@ -35,12 +35,12 @@ zshrc (7 lines)          External script (~150 lines)
 
 ### Step 1: Environment Detection & Migration Check
 
-See [references/migration-check.md](references/migration-check.md) for environment detection, existing installation check, and user confirmation dialogues.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/shell-sync-setup/references/migration-check.md` for environment detection, existing installation check, and user confirmation dialogues.
 
 ### Step 2: Installation
 
-See [references/loader-code.md](references/loader-code.md) for the loader code and installation steps.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/shell-sync-setup/references/loader-code.md` for the loader code and installation steps.
 
 ### Step 3: Verification
 
-See [references/troubleshooting.md](references/troubleshooting.md) for verification and troubleshooting.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/shell-sync-setup/references/troubleshooting.md` for verification and troubleshooting.

--- a/plugins/chezmoi/skills/sync/SKILL.md
+++ b/plugins/chezmoi/skills/sync/SKILL.md
@@ -23,7 +23,9 @@ Run: !`chezmoi update -v`
 
 適用されたファイルをユーザーに報告。
 
-## References
+## Reference Files (read as needed)
 
-- Diff の読み方: [references/diff-interpretation-guide.md](references/diff-interpretation-guide.md)
-- エラー対処: [references/error-handling.md](references/error-handling.md)
+If you need guidance:
+
+- **Diff interpretation**: Read `${CLAUDE_PLUGIN_ROOT}/skills/sync/references/diff-interpretation-guide.md`
+- **Error handling**: Read `${CLAUDE_PLUGIN_ROOT}/skills/sync/references/error-handling.md`

--- a/plugins/code/skills/review-commit/SKILL.md
+++ b/plugins/code/skills/review-commit/SKILL.md
@@ -43,7 +43,7 @@ Team Lead (yourself)
 - Does NOT fix minor issues
 - Reports completion to Team Lead
 
-For detailed review criteria, see [references/review-criteria.md](references/review-criteria.md).
+For detailed review criteria, read `${CLAUDE_PLUGIN_ROOT}/skills/review-commit/references/review-criteria.md`.
 
 ## Step 3: Iterative Review Loop
 


### PR DESCRIPTION
## 概要

MarkdownリンクからCLAUDE_PLUGIN_ROOT環境変数パターンへ移行

## 変更内容

- chezmoi（4スキル）とcode（1スキル）のProgressive Disclosure実装を修正
- Markdownリンク形式 → `${CLAUDE_PLUGIN_ROOT}` 形式に統一
- YPMの正しい実装パターンに準拠

## 影響範囲

- plugins/chezmoi/skills/commit/SKILL.md（2ファイル参照）
- plugins/chezmoi/skills/setup/SKILL.md（6ファイル参照）
- plugins/chezmoi/skills/shell-sync-setup/SKILL.md（3ファイル参照）
- plugins/chezmoi/skills/sync/SKILL.md（2ファイル参照）
- plugins/code/skills/review-commit/SKILL.md（1ファイル参照）

## 検証結果

- Pattern Consistency: PASS
- Environment Variable Syntax: PASS
- Reference File Existence: PASS
- No Remaining Old-Style Links: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)