### PR TITLE
docs(phase2): add Progressive Disclosure documentation and templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,9 @@ claude-tools/
 │   ├── specifications.md
 │   ├── architecture.md
 │   ├── development-guide.md
-│   └── onboarding.md
+│   ├── onboarding.md
+│   ├── progressive-disclosure.md
+│   └── skill-template.md
 ├── .claude/           # Claude Code設定
 │   ├── settings.json
 │   └── skills/        # プロジェクト専用スキル
@@ -234,9 +236,45 @@ Script: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/my-script.sh`
 
 **注意**: コードブロック形式（```bash）では展開されない。`!` 構文が必須。
 
+### Progressive Disclosure パターン
+
+**標準実装**: YPMパターン（`${CLAUDE_PLUGIN_ROOT}` 環境変数形式）
+
+**正しい実装**:
+```markdown
+## How to Execute
+
+### Step 1: Planning
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/planning.md` for detailed instructions.
+
+## Reference Files (read as needed)
+
+If you need guidance:
+
+- **Troubleshooting**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/troubleshooting.md`
+- **Advanced**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/advanced.md`
+```
+
+**誤った実装（使用禁止）**:
+```markdown
+## References
+
+- Planning: [references/planning.md](references/planning.md)  ← Markdownリンクは動作しない
+```
+
+**理由**:
+- Markdownリンクは**Claude Codeで自動解決されない**（仕様）
+- 相対パス解決が不安定
+- ワーキングディレクトリ制限でブロックされる
+
+**詳細**: [docs/progressive-disclosure.md](./docs/progressive-disclosure.md)、[docs/skill-template.md](./docs/skill-template.md)
+
 ### 主要ベストプラクティス
 
 1. **Progressive Disclosure**: frontmatter（常時読込）→ 本文（必要時）→ references/（詳細）
+   - YPMパターン（`${CLAUDE_PLUGIN_ROOT}`）を標準として使用
+   - Markdownリンクは使用しない
 2. **決定論的検証**: クリティカルなチェックはスクリプトで実装（言語指示より確実）
 3. **スクリプトバンドル**: 重要な処理は外部スクリプト化し、SKILL.mdから呼び出す
 4. **エージェント委譲**: MANDATORYと明記し、正確なagent名とパラメータを指定

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,8 @@ SignalComposeが提供するClaude Codeプラグインのマーケットプレ�
 | [architecture.md](./architecture.md) | リポジトリ構成・プラグイン管理方式 |
 | [development-guide.md](./development-guide.md) | プラグイン開発ガイド |
 | [onboarding.md](./onboarding.md) | 新規コントリビューター向けガイド |
+| [progressive-disclosure.md](./progressive-disclosure.md) | Progressive Disclosure標準パターン |
+| [skill-template.md](./skill-template.md) | スキル作成テンプレート |
 
 ## Research
 

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -1,0 +1,293 @@
+# Progressive Disclosure in Claude Code Skills
+
+## Overview
+
+Progressive Disclosure is a design pattern for Claude Code skills that loads information incrementally as needed, rather than loading everything upfront. This improves performance, reduces context window usage, and makes skills easier to maintain.
+
+## The Problem
+
+Early skill implementations used Markdown relative links to reference additional documentation:
+
+```markdown
+## References
+
+- Setup guide: [references/setup-guide.md](references/setup-guide.md)
+- Troubleshooting: [references/troubleshooting.md](references/troubleshooting.md)
+```
+
+**Why this doesn't work:**
+
+1. **Claude Code doesn't auto-resolve Markdown links** - This is by design, not a bug
+2. **Relative path resolution is unreliable** - Depends on working directory context
+3. **Working directory restrictions** - Plugin cache directories may be outside allowed paths
+4. **Sandbox limitations** - File access outside working directories can be blocked
+
+## The Solution: `${CLAUDE_PLUGIN_ROOT}` Pattern
+
+Claude Code provides the `${CLAUDE_PLUGIN_ROOT}` environment variable for plugin-internal paths.
+
+### Correct Implementation (YPM Pattern)
+
+```markdown
+## How to Execute
+
+### Step 1: Planning Phase
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/planning-guide.md` for detailed planning instructions.
+
+### Step 2: Setup Phase
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/setup-guide.md` for setup steps.
+
+## Reference Files (read as needed)
+
+If you need additional guidance:
+
+- **Troubleshooting**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/troubleshooting.md`
+- **Advanced options**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/advanced.md`
+```
+
+### Why This Works
+
+1. **Runtime Resolution**: `${CLAUDE_PLUGIN_ROOT}` expands to the actual plugin installation path
+   - Example: `~/.claude/plugins/cache/claude-tools/plugin-name/abc123/`
+
+2. **Cache-Aware**: Works correctly with Claude Code's plugin caching system
+   - Each commit version has its own cache directory
+   - Reference files always match the skill version
+
+3. **Working Directory Independent**: Doesn't rely on current working directory
+   - Plugin can be invoked from any directory
+   - Paths always resolve correctly
+
+4. **Explicit Instructions**: "Read `${CLAUDE_PLUGIN_ROOT}/...`" tells Claude to load the file
+   - Clear, actionable instruction
+   - No ambiguity about when to load
+
+## Directory Structure
+
+```
+plugins/
+└── your-plugin/
+    └── skills/
+        └── skill-name/
+            ├── SKILL.md              # Main skill file (always loaded)
+            └── references/           # Additional documentation (load as needed)
+                ├── topic-1.md
+                ├── topic-2.md
+                └── troubleshooting.md
+```
+
+## Three-Level Information Architecture
+
+Progressive Disclosure implements a three-level architecture:
+
+### Level 1: Frontmatter (Always Loaded)
+
+```yaml
+---
+name: skill-name
+description: Brief description
+user-invocable: false
+---
+```
+
+**Purpose**: Metadata for skill discovery and invocation
+
+### Level 2: Main Body (Loaded on Invocation)
+
+```markdown
+# Skill Title
+
+Brief overview of what the skill does.
+
+## How to Execute
+
+Step-by-step instructions with explicit "Read" directives for reference files.
+```
+
+**Purpose**: Core instructions and execution flow (~80 lines recommended)
+
+### Level 3: References (Load as Needed)
+
+```
+references/
+├── detailed-examples.md     # Loaded when examples needed
+├── troubleshooting.md       # Loaded when errors occur
+└── advanced-options.md      # Loaded for complex scenarios
+```
+
+**Purpose**: Detailed documentation loaded conditionally
+
+## Migration Guide
+
+### From Markdown Links to Environment Variables
+
+**Before (Incorrect)**:
+```markdown
+## References
+
+- Setup: [references/setup.md](references/setup.md)
+- Errors: [references/errors.md](references/errors.md)
+```
+
+**After (Correct)**:
+```markdown
+## Reference Files (read as needed)
+
+If you need guidance:
+
+- **Setup**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/setup.md`
+- **Error handling**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/errors.md`
+```
+
+### Step-by-Step Migration
+
+1. **Identify Markdown Links**
+   ```bash
+   grep -r "\[references/" plugins/your-plugin/skills/
+   ```
+
+2. **Convert Each Link**
+   - Replace `[text](references/file.md)`
+   - With `Read \`${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/file.md\``
+
+3. **Update Section Headings**
+   - Change `## References` to `## Reference Files (read as needed)`
+   - Add introductory text: "If you need guidance:"
+
+4. **Verify File Paths**
+   ```bash
+   # Check all referenced files exist
+   ls -la plugins/your-plugin/skills/skill-name/references/
+   ```
+
+5. **Test the Skill**
+   - Invoke the skill
+   - Verify reference files load correctly
+   - Check that `${CLAUDE_PLUGIN_ROOT}` expands properly
+
+## Best Practices
+
+### 1. Use Descriptive Labels
+
+```markdown
+- **Diff interpretation**: Read `${CLAUDE_PLUGIN_ROOT}/skills/sync/references/diff-guide.md`
+```
+
+Not just the filename - explain what the reference provides.
+
+### 2. Group Related References
+
+```markdown
+## Reference Files (read as needed)
+
+**For setup issues**:
+- Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/troubleshooting.md`
+
+**For advanced configuration**:
+- Read `${CLAUDE_PLUGIN_ROOT}/skills/setup/references/advanced-config.md`
+```
+
+### 3. Make Loading Conditional
+
+```markdown
+If the installation fails, read troubleshooting guide:
+`${CLAUDE_PLUGIN_ROOT}/skills/setup/references/troubleshooting.md`
+```
+
+Only suggest loading when actually needed.
+
+### 4. Keep Main Body Concise
+
+- Target: ~80 lines for main SKILL.md body
+- Move detailed examples to references/
+- Move troubleshooting to references/
+- Move advanced options to references/
+
+### 5. Maintain Reference Files
+
+- Keep reference files focused on one topic
+- Update references when code changes
+- Delete obsolete references
+- Verify all referenced files exist
+
+## Verification Checklist
+
+Before committing Progressive Disclosure changes:
+
+- [ ] All `${CLAUDE_PLUGIN_ROOT}` paths use curly braces (not `$CLAUDE_PLUGIN_ROOT`)
+- [ ] All referenced files exist in the references/ directory
+- [ ] No Markdown link references (`[text](references/file.md)`) remain
+- [ ] Section headings clearly indicate optional loading
+- [ ] Instructions explicitly say "Read `${CLAUDE_PLUGIN_ROOT}/...`"
+- [ ] File paths are correct (skill name matches directory name)
+- [ ] References are organized logically (grouped by purpose)
+
+## Examples from claude-tools
+
+### YPM project-bootstrap (10 references)
+
+```markdown
+## How to Execute
+
+For each phase, read the corresponding reference file to get detailed instructions:
+
+- **Phase 1**: Read `${CLAUDE_PLUGIN_ROOT}/skills/project-bootstrap/references/phase-1-planning.md`
+- **Phase 2**: Read `${CLAUDE_PLUGIN_ROOT}/skills/project-bootstrap/references/phase-2-directory.md`
+...
+```
+
+### chezmoi sync (2 references)
+
+```markdown
+## Reference Files (read as needed)
+
+If you need guidance:
+
+- **Diff interpretation**: Read `${CLAUDE_PLUGIN_ROOT}/skills/sync/references/diff-interpretation-guide.md`
+- **Error handling**: Read `${CLAUDE_PLUGIN_ROOT}/skills/sync/references/error-handling.md`
+```
+
+### code review-commit (1 reference)
+
+```markdown
+For detailed review criteria, read `${CLAUDE_PLUGIN_ROOT}/skills/review-commit/references/review-criteria.md`.
+```
+
+## Troubleshooting
+
+### Issue: "File not found" errors
+
+**Cause**: Incorrect file path in `${CLAUDE_PLUGIN_ROOT}/...` reference
+
+**Solution**:
+1. Verify file exists: `ls plugins/plugin-name/skills/skill-name/references/file.md`
+2. Check skill name matches directory: `skills/skill-name/` in path
+3. Verify spelling of filename
+
+### Issue: References not loading
+
+**Cause**: Missing "Read" instruction
+
+**Solution**: Ensure you use explicit "Read `${CLAUDE_PLUGIN_ROOT}/...`" pattern
+
+### Issue: Variable not expanding
+
+**Cause**: Missing curly braces or incorrect syntax
+
+**Solution**: Use `${CLAUDE_PLUGIN_ROOT}` (with braces), not `$CLAUDE_PLUGIN_ROOT`
+
+## Further Reading
+
+- [CLAUDE.md](../CLAUDE.md) - Project conventions and skill development guidelines
+- [skill-template.md](./skill-template.md) - Template for new skills with Progressive Disclosure
+- [Claude Code Plugins Documentation](https://code.claude.com/docs/en/plugins)
+
+## Changelog
+
+- **2026-02-12**: Phase 2 - Created comprehensive documentation
+  - Added progressive-disclosure.md (this document)
+  - Added skill-template.md for new skill development
+  - Updated CLAUDE.md with Progressive Disclosure guidelines
+  - Phase 1 (PR #104): Migrated 5 skills from Markdown links to `${CLAUDE_PLUGIN_ROOT}` pattern

--- a/docs/skill-template.md
+++ b/docs/skill-template.md
@@ -1,0 +1,374 @@
+# Skill Template
+
+Template for creating new Claude Code skills with Progressive Disclosure.
+
+## Basic Skill Template
+
+```markdown
+---
+name: skill-name
+description: |
+  Brief description of what the skill does.
+  Use when: "trigger phrase 1", "trigger phrase 2",
+  "Japanese trigger", "別のトリガー".
+user-invocable: false
+---
+
+# Skill Title
+
+Brief overview of the skill's purpose and functionality.
+
+## Core Principles
+
+List key principles that guide skill execution (if applicable):
+1. Principle 1
+2. Principle 2
+3. Principle 3
+
+## How to Execute
+
+### Step 1: [First Step Name]
+
+Clear, actionable instructions for the first step.
+
+Run: !`command-to-execute`
+
+### Step 2: [Second Step Name]
+
+Instructions for the second step.
+
+### Step 3: [Third Step Name]
+
+Instructions for the third step.
+
+## Reference Files (read as needed)
+
+If you need additional guidance:
+
+- **Topic 1**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/topic-1.md`
+- **Topic 2**: Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/topic-2.md`
+```
+
+## Progressive Disclosure Template
+
+For skills with substantial reference documentation:
+
+```markdown
+---
+name: complex-skill
+description: |
+  Multi-phase skill with extensive documentation.
+  Use when: "trigger phrases".
+user-invocable: false
+---
+
+# Complex Skill Title
+
+Overview of the skill's multi-phase workflow.
+
+## Phase Overview
+
+| Phase | Name | Key Actions |
+|-------|------|-------------|
+| 1 | Phase Name | Key action summary |
+| 2 | Phase Name | Key action summary |
+| 3 | Phase Name | Key action summary |
+
+## How to Execute
+
+For each phase, read the corresponding reference file:
+
+- **Phase 1**: Read `${CLAUDE_PLUGIN_ROOT}/skills/complex-skill/references/phase-1.md`
+- **Phase 2**: Read `${CLAUDE_PLUGIN_ROOT}/skills/complex-skill/references/phase-2.md`
+- **Phase 3**: Read `${CLAUDE_PLUGIN_ROOT}/skills/complex-skill/references/phase-3.md`
+
+**Additional references** (load as needed during relevant phases):
+- **Troubleshooting**: Read `${CLAUDE_PLUGIN_ROOT}/skills/complex-skill/references/troubleshooting.md`
+- **Advanced options**: Read `${CLAUDE_PLUGIN_ROOT}/skills/complex-skill/references/advanced.md`
+
+## Phase Transition Protocol
+
+At the end of each phase:
+
+1. Verify completion criteria are met
+2. Report completed artifacts to the user
+3. Ask: "Phase N is complete. Proceed to Phase N+1?"
+4. **Wait for user approval** before continuing
+```
+
+## Directory Structure Template
+
+```
+plugins/
+└── your-plugin/
+    └── skills/
+        └── skill-name/
+            ├── SKILL.md              # Main skill file (use template above)
+            └── references/           # Reference documentation
+                ├── phase-1.md        # For multi-phase skills
+                ├── phase-2.md
+                ├── troubleshooting.md
+                ├── advanced.md
+                └── examples.md
+```
+
+## Frontmatter Guidelines
+
+### Required Fields
+
+```yaml
+---
+name: skill-name                    # Must match directory name
+description: |                      # Multi-line description
+  What the skill does.
+  Trigger phrases for invocation.
+user-invocable: false              # Usually false for skills
+---
+```
+
+### Optional Fields
+
+```yaml
+---
+name: skill-name
+description: |
+  Skill description.
+user-invocable: false
+allowed-tools:                     # ⚠ CAUTION: May conflict with ! execution syntax
+  - Bash                           # Known to be unstable in some configurations
+  - Read                           # Use only if absolutely necessary
+  - Write
+---
+```
+
+**Note**: The `allowed-tools` field can cause intermittent issues when combined with `!` execution syntax. Use with caution and test thoroughly. Prefer skills without tool restrictions when possible.
+
+## Best Practices
+
+### 1. Keep Main Body Concise
+
+**Target**: ~80 lines for SKILL.md main body
+- Core instructions only
+- Step-by-step execution flow
+- References to detailed documentation
+
+**Move to references/**:
+- Detailed examples
+- Troubleshooting guides
+- Advanced configuration
+- Edge case handling
+
+### 2. Use Clear Execution Instructions
+
+**Good**:
+```markdown
+### Step 1: Check Status
+
+Run: !`git status`
+
+Verify there are changes to commit.
+```
+
+**Not as clear**:
+```markdown
+### Step 1
+
+Check if there are changes.
+```
+
+### 3. Explicit Reference Loading
+
+**Good**:
+```markdown
+If you encounter errors, read the troubleshooting guide:
+`${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/troubleshooting.md`
+```
+
+**Avoid**:
+```markdown
+See troubleshooting.md for errors.
+```
+
+### 4. Group Related References
+
+```markdown
+## Reference Files (read as needed)
+
+**For setup**:
+- Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/setup-guide.md`
+
+**For troubleshooting**:
+- Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/common-errors.md`
+- Read `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/debugging.md`
+```
+
+### 5. Use Descriptive Labels
+
+```markdown
+- **Diff interpretation**: Read `${CLAUDE_PLUGIN_ROOT}/skills/sync/references/diff-guide.md`
+```
+
+Not just the filename - explain what guidance the reference provides.
+
+## Reference File Template
+
+Template for individual reference files:
+
+```markdown
+# [Topic Name]
+
+Brief introduction to this topic.
+
+## Overview
+
+What this reference covers and when to use it.
+
+## Detailed Instructions
+
+### Sub-topic 1
+
+Detailed explanation with examples.
+
+### Sub-topic 2
+
+More detailed content.
+
+## Examples
+
+Concrete examples demonstrating the concepts.
+
+## Common Issues
+
+FAQ-style troubleshooting specific to this topic.
+
+## See Also
+
+- Related reference: `${CLAUDE_PLUGIN_ROOT}/skills/skill-name/references/related.md`
+```
+
+## Skill Naming Conventions
+
+### Skill Names
+
+- Use kebab-case: `project-bootstrap`, `review-commit`, `shell-sync-setup`
+- Be descriptive: name should indicate purpose
+- Match directory name exactly
+
+### Reference File Names
+
+- Use kebab-case: `phase-1-planning.md`, `diff-interpretation-guide.md`
+- Be specific: indicate content clearly
+- Group related files with prefixes: `phase-1-*.md`, `phase-2-*.md`
+
+## Testing Your Skill
+
+### Verification Checklist
+
+Before committing a new skill:
+
+- [ ] Frontmatter is valid YAML
+- [ ] `name` field matches directory name
+- [ ] All `${CLAUDE_PLUGIN_ROOT}` paths are correct
+- [ ] All referenced files exist in `references/` directory
+- [ ] No Markdown relative links remain
+- [ ] Main body is concise (~80 lines)
+- [ ] Instructions are clear and actionable
+- [ ] Reference files are well-organized
+- [ ] Skill invocation triggers work correctly
+
+### Manual Testing
+
+1. **Invoke the skill**:
+   ```
+   /plugin:skill-name
+   ```
+
+2. **Verify reference loading**:
+   - Trigger conditions that should load references
+   - Confirm files load without errors
+   - Check that content is relevant
+
+3. **Test edge cases**:
+   - What happens with no input?
+   - What happens with invalid input?
+   - Are error messages helpful?
+
+4. **Check working directory independence**:
+   - Invoke from different directories
+   - Verify `${CLAUDE_PLUGIN_ROOT}` expands correctly
+
+## Examples from claude-tools
+
+### Simple Skill: chezmoi/commit
+
+```markdown
+---
+name: commit
+description: |
+  Commit and push changed dotfiles to remote repository.
+  Use when: "commit dotfiles", "push dotfiles".
+user-invocable: false
+---
+
+# Chezmoi Commit
+
+Detect changed dotfiles, commit and push to remote.
+
+## Diff Interpretation
+
+Use `chezmoi diff --reverse` to get git-like diff output.
+
+For detailed examples, read `${CLAUDE_PLUGIN_ROOT}/skills/commit/references/diff-interpretation.md`.
+
+## Execution
+
+### Step 1: Detect & Show Changes
+...
+```
+
+### Complex Skill: ypm/project-bootstrap
+
+```markdown
+---
+name: project-bootstrap
+description: |
+  Interactive 8-phase new project setup wizard.
+user-invocable: false
+---
+
+# Project Bootstrap Wizard
+
+## Phase Overview
+
+| Phase | Name | Key Actions |
+|-------|------|-------------|
+| 1 | Planning | Requirements gathering |
+| 2 | Directory | Local setup, git init |
+...
+
+## How to Execute
+
+For each phase, read the corresponding reference file:
+
+- **Phase 1**: Read `${CLAUDE_PLUGIN_ROOT}/skills/project-bootstrap/references/phase-1-planning.md`
+...
+```
+
+## Migration from Old Patterns
+
+If you have an existing skill using Markdown links:
+
+1. See [progressive-disclosure.md](./progressive-disclosure.md) for full migration guide
+2. Use the "Migration Guide" section
+3. Verify all paths after migration
+4. Test skill invocation thoroughly
+
+## Further Reading
+
+- [progressive-disclosure.md](./progressive-disclosure.md) - Progressive Disclosure pattern details
+- [CLAUDE.md](../CLAUDE.md) - Project conventions
+- [Anthropic Skill Building Guide](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+
+## Changelog
+
+- **2026-02-12**: Initial template after Progressive Disclosure standardization (Phase 2)


### PR DESCRIPTION
## 概要

Phase 2完了: Progressive Disclosure標準パターンのドキュメント整備

## 追加ファイル

- `docs/progressive-disclosure.md` - Progressive Disclosure標準パターンの包括的ガイド
  - Claude Code標準パターン（YPMパターン）の説明
  - Markdownリンクが動作しない理由の解説
  - 移行ガイドとベストプラクティス
  - トラブルシューティング

- `docs/skill-template.md` - 新規スキル作成テンプレート
  - Basic Skill Template
  - Progressive Disclosure Template
  - フロントマター、参照ファイルのガイドライン
  - テストとチェックリスト

## 更新ファイル

- `CLAUDE.md` - Progressive Disclosureセクション追加
  - YPMパターンの説明と実装例
  - 誤った実装（Markdownリンク）の警告
  - ベストプラクティスの更新

- `docs/INDEX.md` - 新ドキュメントへのリンク追加

## Phase 1との関係

- Phase 1 (PR #104): 5つのスキルを移行（実装レベル）
- Phase 2 (このPR): 標準パターンをドキュメント化（知識共有）

## 検証結果

- Cross-reference accuracy: PASS
- CLAUDE.md consistency: PASS
- INDEX.md consistency: PASS
- Documentation internal consistency: PASS
- Content accuracy: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)