### PR TITLE
feat(cvi): Add sandbox auto-detection to Stop hook

### DIFF
--- a/plugins/cvi/scripts/check-speak-called.sh
+++ b/plugins/cvi/scripts/check-speak-called.sh
@@ -26,7 +26,7 @@ is_sandbox_enabled() {
 
     # Priority 1: Check settings.local.json
     if [ -f "$SETTINGS_LOCAL" ]; then
-        local sandbox_enabled=$(jq -r '.sandbox.enabled // "null"' "$SETTINGS_LOCAL" 2>/dev/null)
+        local sandbox_enabled=$(jq -r '.sandbox.enabled // "null"' "$SETTINGS_LOCAL" 2>/dev/null || echo "null")
         if [ "$sandbox_enabled" = "true" ]; then
             return 0  # Sandbox enabled
         elif [ "$sandbox_enabled" = "false" ]; then
@@ -36,13 +36,15 @@ is_sandbox_enabled() {
 
     # Priority 2: Check settings.json
     if [ -f "$SETTINGS_GLOBAL" ]; then
-        local sandbox_enabled=$(jq -r '.sandbox.enabled // "null"' "$SETTINGS_GLOBAL" 2>/dev/null)
+        local sandbox_enabled=$(jq -r '.sandbox.enabled // "null"' "$SETTINGS_GLOBAL" 2>/dev/null || echo "null")
         if [ "$sandbox_enabled" = "true" ]; then
             return 0  # Sandbox enabled
         fi
     fi
 
     # Default: Assume disabled if not specified
+    # Rationale: Prioritize CVI notifications over sandbox detection failures
+    # If sandbox state is unknown, allow CVI checks to run to avoid missing notifications
     return 1
 }
 


### PR DESCRIPTION
## 概要

Sandbox有効時に`/cvi:speak`チェックをスキップする機能を追加しました。

## 問題

Sandbox有効時、`/cvi:speak`コマンドがAudioQueueStartエラー（`-66680`）で失敗しますが、Stop hookは`/cvi:speak`が呼ばれたかをチェックするため、ユーザーは常にブロックされていました。

## 解決策

Stop hookでsandbox状態を自動検出し、sandbox有効時はCVIチェックをスキップします。

## 変更内容

- `is_sandbox_enabled()`関数を追加
  - `~/.claude/settings.local.json` → `~/.claude/settings.json` の優先順位でsandbox状態を検出
  - JSONパースエラー時は graceful degradation（デフォルト動作を維持）
- Sandbox有効時は`exit 0`で早期終了（CVIチェックをスキップ）
- 既存の動作を変更しない（backward compatible）

## テスト

- ✅ コードレビュー完了（Critical/Important問題: 0件）
- ✅ セキュリティ、ロジック、ベストプラクティスすべてクリア

## 関連ドキュメント

- 実装プラン: `.claude/plans/giggly-painting-sedgewick.md`