### PR TITLE
feat(utils): add -y/--yes option to clear-plugin-cache command

### DIFF
--- a/plugins/utils/commands/clear-plugin-cache.md
+++ b/plugins/utils/commands/clear-plugin-cache.md
@@ -1,6 +1,6 @@
 ---
 description: Clear plugin cache to fix stale version issues after /plugin update
-argument-hint: <plugin-name> [--marketplace <name>] [--all] [--dry-run]
+argument-hint: <plugin-name> [--marketplace <name>] [--all] [--dry-run] [-y/--yes]
 ---
 
 # Clear Plugin Cache
@@ -31,12 +31,14 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh $ARGUMENTS
 | `--marketplace <name>` | Specify marketplace (default: claude-tools) |
 | `--all` | Clear all plugin caches for the specified marketplace |
 | `--dry-run` | Show what would be deleted without actually deleting |
+| `-y, --yes` | Skip confirmation prompt (useful for automated workflows) |
 
 ## Examples
 
 - Clear single plugin: `/utils:clear-plugin-cache cvi`
 - Clear with marketplace: `/utils:clear-plugin-cache plugin --marketplace other-market`
 - Clear all: `/utils:clear-plugin-cache --all --marketplace claude-tools`
+- Clear all (skip confirmation): `/utils:clear-plugin-cache --all --marketplace claude-tools -y`
 - Dry run: `/utils:clear-plugin-cache cvi --dry-run`
 
 ## After Clearing

--- a/plugins/utils/scripts/clear-plugin-cache.sh
+++ b/plugins/utils/scripts/clear-plugin-cache.sh
@@ -11,6 +11,7 @@ MARKETPLACE_SPECIFIED=false
 PLUGIN_NAME=""
 ALL_PLUGINS=false
 DRY_RUN=false
+SKIP_CONFIRMATION=false
 CACHE_BASE_DIR="$HOME/.claude/plugins/cache"
 
 # Colors for output
@@ -41,6 +42,7 @@ Options:
   --marketplace <name>     Marketplace name (default: claude-tools)
   --all                    Clear all plugin caches for the marketplace
   --dry-run                Show what would be deleted without deleting
+  -y, --yes                Skip confirmation prompt
   -h, --help               Show this help message
 
 Examples:
@@ -48,6 +50,7 @@ Examples:
   clear-plugin-cache cvi --dry-run
   clear-plugin-cache plugin --marketplace other-market
   clear-plugin-cache --all --marketplace claude-tools
+  clear-plugin-cache --all --marketplace claude-tools -y
 EOF
 }
 
@@ -65,6 +68,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        -y|--yes)
+            SKIP_CONFIRMATION=true
             shift
             ;;
         -h|--help)
@@ -141,7 +148,7 @@ delete_plugin_cache() {
 # Clear cache
 if [[ "$ALL_PLUGINS" == true ]]; then
     # Confirmation for --all
-    if [[ "$DRY_RUN" == false ]]; then
+    if [[ "$DRY_RUN" == false ]] && [[ "$SKIP_CONFIRMATION" == false ]]; then
         echo ""
         print_warning "This will delete ALL plugin caches for marketplace: $MARKETPLACE"
         echo ""


### PR DESCRIPTION
## Summary

`clear-plugin-cache.sh` スクリプトに `-y/--yes` オプションを追加しました。これにより、`--all` モード使用時の対話的な確認プロンプトをスキップできるようになります。

## Motivation

現在、`/utils:clear-plugin-cache --all --marketplace claude-tools` を実行すると、スクリプトは確認プロンプトを表示します。非対話的環境（Claude Code の Bash ツールなど）では、これによりスクリプトがブロックされ、`yes` コマンドをパイプで渡す回避策が必要でした。

## Changes

- `SKIP_CONFIRMATION` 変数を追加（デフォルト: `false`）
- `-y|--yes` オプションの解析を追加
- 確認ロジックを更新：`DRY_RUN` と `SKIP_CONFIRMATION` の両方をチェック
- 使用方法ドキュメントを更新（スクリプトとコマンドMD）
- 使用例を追加

## Testing

- ✅ ヘルプメッセージが正しく表示される
- ✅ `--dry-run` モードが確認プロンプトなしで動作する
- ✅ `-y` オプションが正しく解析される
- ✅ `--yes` オプション（長い形式）が正しく解析される

## Test plan

- [ ] `/utils:clear-plugin-cache --all --marketplace claude-tools -y` を実行
- [ ] 確認プロンプトなしでキャッシュが削除されることを確認
- [ ] Claude Code を再起動して変更が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)