### PR TITLE
fix(utils): quote $ARGUMENTS in clear-plugin-cache command

### DIFF
--- a/plugins/utils/commands/clear-plugin-cache.md
+++ b/plugins/utils/commands/clear-plugin-cache.md
@@ -20,7 +20,7 @@ Related issues:
 以下のBashコマンドを**即座に実行**してください（確認ダイアログなし）:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh $ARGUMENTS
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh "$ARGUMENTS"
 ```
 
 ## Arguments


### PR DESCRIPTION
## 概要

`/utils:clear-plugin-cache`コマンドが反応しない問題を修正。

## 問題

**症状**:
- `/utils:clear-plugin-cache --all --marketplace claude-tools -y` が反応しない
- コマンド実行しても何も起こらない

**原因**:
- `plugins/utils/commands/clear-plugin-cache.md` Line 23
- `$ARGUMENTS` がクォートされていない
- スペースで引数が分割され、スクリプトが正しく解釈できない

## 修正内容

**変更**: 1行のみ
```diff
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh $ARGUMENTS
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/clear-plugin-cache.sh "$ARGUMENTS"
```

**CVIパターンに準拠**:
- `$ARGUMENTS` は必ず `"$ARGUMENTS"` とクォート
- MEMORYに記録された安定パターン

## 検証

**他のコマンドの確認**:
- cvi/commands/speak.md: `"$ARGUMENTS"` ✅
- codex/commands/research.md: `"$ARGUMENTS"` ✅
- gemini/commands/search.md: `"$ARGUMENTS"` ✅
- utils/commands/clear-plugin-cache.md: `$ARGUMENTS` ❌（修正済み）

## 影響範囲

- `/utils:clear-plugin-cache`コマンドのみ
- 他のコマンドは正しく実装されている

## テスト

修正後、以下のコマンドが正常に動作するはず：
```bash
/utils:clear-plugin-cache chezmoi
/utils:clear-plugin-cache --all --marketplace claude-tools -y
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)