### PR TITLE
fix(chezmoi): fix timeout command variable expansion in shell-check.zsh

### DIFF
--- a/plugins/chezmoi/scripts/shell-check.zsh
+++ b/plugins/chezmoi/scripts/shell-check.zsh
@@ -59,19 +59,19 @@ function _chezmoi_check_sync() {
   # Network check and git fetch with timeout (portable: uses curl)
   if curl -s --connect-timeout 2 --max-time 3 https://github.com >/dev/null 2>&1; then
     # Git fetch with timeout (use gtimeout on macOS if available)
-    local timeout_cmd=""
+    local -a timeout_cmd=()
     if command -v timeout &>/dev/null; then
-      timeout_cmd="timeout 10"
+      timeout_cmd=(timeout 10)
     elif command -v gtimeout &>/dev/null; then
-      timeout_cmd="gtimeout 10"
+      timeout_cmd=(gtimeout 10)
     fi
 
     # Detect default branch (fallback to main)
     local default_branch=$(git -C "$CHEZMOI_DIR" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
     [[ -z "$default_branch" ]] && default_branch="main"
 
-    if [[ -n "$timeout_cmd" ]]; then
-      $timeout_cmd git -C "$CHEZMOI_DIR" fetch origin "$default_branch" --quiet 2>&1 || fetch_failed=true
+    if [[ ${#timeout_cmd[@]} -gt 0 ]]; then
+      "${timeout_cmd[@]}" git -C "$CHEZMOI_DIR" fetch origin "$default_branch" --quiet 2>&1 || fetch_failed=true
     else
       # No timeout available, run with risk of hanging (but curl check passed)
       git -C "$CHEZMOI_DIR" fetch origin "$default_branch" --quiet 2>&1 || fetch_failed=true


### PR DESCRIPTION
## Summary

変数展開のバグを修正。文字列変数から配列変数に変更することで、`timeout 10`が正しく2つの引数として展開されるようにした。

## 問題の詳細

**エラー**:
```
_chezmoi_check_sync:50: command not found: timeout 10
```

**原因**:
- zshでは文字列変数展開（`$var`）は単語分割されない
- `timeout_cmd="timeout 10"`を`$timeout_cmd`として展開すると、`"timeout 10"`が1つのコマンド名として解釈される

## 変更内容

- Line 62: `local timeout_cmd=""` → `local -a timeout_cmd=()`
- Line 64-66: 文字列代入 → 配列代入
- Line 73: 文字列チェック → 配列長チェック  
- Line 74: 文字列展開 → 配列展開`"${timeout_cmd[@]}"`

## 一貫性の確保

既存の`chezmoi_status_cmd`パターン（lines 106-113）と同じ実装に統一。

## Test plan

- [x] コードレビュー完了（pr-review-toolkit:code-reviewer）
- [ ] マージ後、`/plugin update`で更新
- [ ] `/utils:clear-plugin-cache chezmoi`でキャッシュクリア
- [ ] Claude Code再起動
- [ ] 新しいターミナルでEnter押下時にエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)