### PR TITLE
fix(code): correct PreToolUse hook matcher to tool name only

### DIFF
--- a/plugins/code/hooks/hooks.json
+++ b/plugins/code/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash(*git commit*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## 概要

PreToolUse フック matcher の無効な正規表現パターンを修正。

## 変更内容

### 1. Hooks Matcher の修正
**ファイル**: `plugins/code/hooks/hooks.json`
- **変更前**: `"matcher": "Bash(*git commit*)"`
- **変更後**: `"matcher": "Bash"`
- **理由**: 公式ドキュメントによると、matcher はツール名のみにマッチ

## 調査結果

公式 hooks ドキュメントにより、PreToolUse の `matcher` フィールドは：
- `tool_name` フィールドにマッチ
- ツール名に対する正規表現を使用：`"Bash"`, `"Edit|Write"` など
- ツールパラメータにはマッチしない

スクリプト `check-code-review.sh` は既に内部で git commit のフィルタリングを処理。

## コードレビュー

✅ pr-review-toolkit:code-reviewer agent による自動レビュー完了
- Critical issues: 0
- Important issues: 0
- Minor issues: 0

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)