### PR TITLE
fix(codex): resolve sandbox crash by adding dangerouslyDisableSandbox instruction

### DIFF
--- a/plugins/codex/commands/research.md
+++ b/plugins/codex/commands/research.md
@@ -22,6 +22,8 @@ If this fails, inform the user to install Codex CLI:
 
 2. **Execute Research Query**
 
+**IMPORTANT**: The codex CLI requires access to macOS system configuration APIs that are blocked by Claude Code's sandbox. You MUST use `dangerouslyDisableSandbox: true` when executing this script. Without this, codex CLI will crash with exit code 101.
+
 Run the research with the provided arguments:
 
 ```bash

--- a/plugins/codex/commands/review.md
+++ b/plugins/codex/commands/review.md
@@ -22,6 +22,8 @@ If this fails, inform the user to install Codex CLI:
 
 2. **Execute Code Review**
 
+**IMPORTANT**: The codex CLI requires access to macOS system configuration APIs that are blocked by Claude Code's sandbox. You MUST use `dangerouslyDisableSandbox: true` when executing this script. Without this, codex CLI will crash with exit code 101.
+
 Run the review with the provided arguments:
 
 ```bash


### PR DESCRIPTION
## Summary

- codex プラグインが Claude Code の sandbox 環境でクラッシュする問題を修正
- コマンドファイルに `dangerouslyDisableSandbox: true` の使用指示を追加
- macOS の `SCDynamicStore` API アクセス制限が根本原因

## Test plan

- [ ] Claude Code から `/codex:research` を実行してクラッシュしないことを確認
- [ ] Claude Code から `/codex:review --staged` を実行してクラッシュしないことを確認
- [ ] Claude Code から `/codex:review <file>` を実行してクラッシュしないことを確認
- [ ] ターミナルから直接実行しても動作することを確認（後方互換性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)