### PR TITLE
Fix kiro and gemini commands with sandbox bypass instructions

### DIFF
--- a/plugins/gemini/commands/search.md
+++ b/plugins/gemini/commands/search.md
@@ -18,11 +18,15 @@ If the check fails, guide the user through installation.
 
 ## Step 2: Execute Search
 
+**IMPORTANT**: The Gemini CLI requires write access to configuration and cache directories that are blocked by Claude Code's sandbox. You MUST use `dangerouslyDisableSandbox: true` when executing this script. Without this, the Gemini CLI will fail with shell command errors.
+
 Run the search with the provided query:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/gemini-search.sh "$ARGUMENTS"
 ```
+
+When calling the Bash tool, set `dangerouslyDisableSandbox: true` to allow configuration file operations.
 
 ## Step 3: Summarize Results
 

--- a/plugins/kiro/commands/research.md
+++ b/plugins/kiro/commands/research.md
@@ -22,11 +22,15 @@ If this fails, inform the user to install Kiro CLI:
 
 2. **Execute Research Query**
 
+**IMPORTANT**: The Kiro CLI requires write access to `~/.kiro` and Application Support directories that are blocked by Claude Code's sandbox. You MUST use `dangerouslyDisableSandbox: true` when executing this script. Without this, the Kiro CLI will fail with "readonly database" errors.
+
 Run the research with the provided arguments:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/kiro-ask.sh "$ARGUMENTS"
 ```
+
+When calling the Bash tool, set `dangerouslyDisableSandbox: true` to allow database write operations.
 
 3. **Summarize Results**
 


### PR DESCRIPTION
## Summary
- kiro と gemini コマンドに `dangerouslyDisableSandbox` の指示を追加
- CLI ツールがローカル設定ファイルやデータベースへの書き込みに失敗する問題を解決
- codex パターンと同じ形式を採用し、一貫性を向上

## Background

実験により、kiro と gemini が sandbox 環境で正常に動作していないことが判明：
- kiro: `~/.kiro` への書き込みが blocked → "readonly database" エラー
- gemini: 設定ファイルへの書き込みが blocked → shell command エラー

## Changes

### kiro/commands/research.md
- コードブロック前に IMPORTANT 警告を追加
- `dangerouslyDisableSandbox: true` の使用を明示
- エラーメッセージ例を含め、理由を説明

### gemini/commands/search.md
- コードブロック前に IMPORTANT 警告を追加
- `dangerouslyDisableSandbox: true` の使用を明示
- エラーメッセージ例を含め、理由を説明

## Test Plan
- [ ] `/kiro:research "What is AWS Lambda?"` が正常に実行される
- [ ] `/gemini:search "Claude Code best practices"` が正常に実行される
- [ ] "readonly database" エラーが発生しない
- [ ] "run_shell_command is not defined" エラーが発生しない

## Related Issues
- Fixes sandbox-related failures in kiro and gemini commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)