### PR TITLE
fix(cvi): decouple ENGLISH_PRACTICE from CVI_ENABLED gate

### DIFF
--- a/plugins/cvi/scripts/enforce-cvi-rules.sh
+++ b/plugins/cvi/scripts/enforce-cvi-rules.sh
@@ -1,30 +1,39 @@
 #!/bin/bash
 # UserPromptSubmit hook: Enforce CVI rules based on config
+set -o pipefail
 
 CONFIG_FILE="$HOME/.cvi/config"
 SETTINGS_FILE="$HOME/.claude/settings.json"
 
 # Read CVI config values
 if [ -f "$CONFIG_FILE" ]; then
-    CVI_ENABLED=$(grep "^CVI_ENABLED=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
-    ENGLISH_PRACTICE=$(grep "^ENGLISH_PRACTICE=" "$CONFIG_FILE" | cut -d'=' -f2)
-else
-    CVI_ENABLED="on"
-    VOICE_LANG="ja"
-    ENGLISH_PRACTICE="off"
+    if [ ! -r "$CONFIG_FILE" ]; then
+        echo "⚠️  WARNING: Config file ${CONFIG_FILE} exists but is not readable. Using defaults." >&2
+    else
+        CVI_ENABLED=$(grep "^CVI_ENABLED=" "$CONFIG_FILE" | cut -d'=' -f2)
+        VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
+        ENGLISH_PRACTICE=$(grep "^ENGLISH_PRACTICE=" "$CONFIG_FILE" | cut -d'=' -f2)
+    fi
 fi
 
-# Read response language from settings.json (needed for ENGLISH_PRACTICE)
-if [ -f "$SETTINGS_FILE" ]; then
-    RESPONSE_LANG=$(grep '"language"' "$SETTINGS_FILE" | sed 's/.*: *"\([^"]*\)".*/\1/')
-fi
-RESPONSE_LANG=${RESPONSE_LANG:-japanese}
+# Normalize config values (lowercase, trim whitespace)
+CVI_ENABLED=$(echo "$CVI_ENABLED" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+VOICE_LANG=$(echo "$VOICE_LANG" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+ENGLISH_PRACTICE=$(echo "$ENGLISH_PRACTICE" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
 
 # Set defaults
 CVI_ENABLED=${CVI_ENABLED:-on}
 VOICE_LANG=${VOICE_LANG:-ja}
 ENGLISH_PRACTICE=${ENGLISH_PRACTICE:-off}
+
+# Read response language from settings.json (used by ENGLISH_PRACTICE and CVI rules)
+if [ -f "$SETTINGS_FILE" ]; then
+    RESPONSE_LANG=$(grep '"language"' "$SETTINGS_FILE" | sed 's/.*: *"\([^"]*\)".*/\1/')
+    if [ -z "$RESPONSE_LANG" ]; then
+        echo "⚠️  WARNING: Could not parse 'language' from ${SETTINGS_FILE}. Defaulting to 'japanese'." >&2
+    fi
+fi
+RESPONSE_LANG=${RESPONSE_LANG:-japanese}
 
 # English Practice mode (independent of CVI_ENABLED)
 if [ "$ENGLISH_PRACTICE" = "on" ]; then

--- a/plugins/cvi/scripts/inject-cvi-context.sh
+++ b/plugins/cvi/scripts/inject-cvi-context.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 # SessionStart hook: Inject CVI-specific context and English Practice mode
+set -o pipefail
 
 CONFIG_FILE="$HOME/.cvi/config"
 
 # Read config values
 if [ -f "$CONFIG_FILE" ]; then
-    CVI_ENABLED=$(grep "^CVI_ENABLED=" "$CONFIG_FILE" | cut -d'=' -f2)
-    VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
-    ENGLISH_PRACTICE=$(grep "^ENGLISH_PRACTICE=" "$CONFIG_FILE" | cut -d'=' -f2)
+    if [ ! -r "$CONFIG_FILE" ]; then
+        echo "⚠️  WARNING: Config file ${CONFIG_FILE} exists but is not readable. Using defaults." >&2
+    else
+        CVI_ENABLED=$(grep "^CVI_ENABLED=" "$CONFIG_FILE" | cut -d'=' -f2)
+        VOICE_LANG=$(grep "^VOICE_LANG=" "$CONFIG_FILE" | cut -d'=' -f2)
+        ENGLISH_PRACTICE=$(grep "^ENGLISH_PRACTICE=" "$CONFIG_FILE" | cut -d'=' -f2)
+    fi
 fi
+
+# Normalize config values (lowercase, trim whitespace)
+CVI_ENABLED=$(echo "$CVI_ENABLED" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+VOICE_LANG=$(echo "$VOICE_LANG" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+ENGLISH_PRACTICE=$(echo "$ENGLISH_PRACTICE" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
 
 # Set defaults
 CVI_ENABLED=${CVI_ENABLED:-on}


### PR DESCRIPTION
## Summary
- `ENGLISH_PRACTICE` のルール注入を `CVI_ENABLED` の early exit より前に移動
- 音声通知を OFF にしても English Practice Mode が独立して動作するように修正
- `enforce-cvi-rules.sh` の重複 Practice Mode ブロックを削除

## 変更理由
`CVI_ENABLED=off` の場合、`inject-cvi-context.sh` と `enforce-cvi-rules.sh` が即座に `exit 0` するため、`ENGLISH_PRACTICE=on` でも Practice Mode ルールがシステムプロンプトに注入されなかった。

`ENGLISH_PRACTICE` は言語学習機能であり、音声通知（`CVI_ENABLED`）とは独立した機能のため、分離が必要。

## 対象ファイル
- `plugins/cvi/scripts/inject-cvi-context.sh`
- `plugins/cvi/scripts/enforce-cvi-rules.sh`

## Test plan
- [x] `CVI_ENABLED=off` + `ENGLISH_PRACTICE=on` → Practice Mode ルールが出力される
- [x] `CVI_ENABLED=off` + `ENGLISH_PRACTICE=off` → 出力なし（即 exit）
- [x] `CVI_ENABLED=on` + `ENGLISH_PRACTICE=off` → CVI ルールのみ出力
- [x] `CVI_ENABLED=on` + `ENGLISH_PRACTICE=on` → 両方出力

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)