### PR TITLE
fix(chezmoi): surface chezmoi status errors instead of silencing them

### DIFF
--- a/plugins/chezmoi/scripts/chezmoi-check.sh
+++ b/plugins/chezmoi/scripts/chezmoi-check.sh
@@ -15,6 +15,7 @@ echo ""
 
 # Step 1: chezmoi status
 echo "🔄 Modified files:"
+STATUS_FAILED=false
 STATUS=$(chezmoi status 2>&1)
 STATUS_EXIT=$?
 if [ $STATUS_EXIT -ne 0 ]; then


### PR DESCRIPTION
## Summary

- `chezmoi-check.sh` が `chezmoi status` のエラーを `2>/dev/null` で破棄していたため、1Password 接続エラー等で失敗しても `(no changes)` と誤報告されていた
- stderr をキャプチャし、終了コードを確認してエラー時は警告を表示するように修正
- Next steps セクションにもエラー時の案内を追加

Closes #126

## Test plan

- [ ] 1Password デスクトップアプリ停止中に `/chezmoi:check` を実行し、エラーが表示されることを確認
- [ ] 1Password 正常時に `/chezmoi:check` を実行し、従来通り動作することを確認
- [ ] chezmoi 未インストール時のエラーメッセージが変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)