### PR TITLE
fix(cvi): handle jq alternative operator treating false as null

### DIFF
--- a/plugins/cvi/scripts/speak-sync.sh
+++ b/plugins/cvi/scripts/speak-sync.sh
@@ -54,7 +54,7 @@ _read_sandbox_setting() {
     fi
 
     local jq_output
-    if ! jq_output=$(jq -r '.sandbox.enabled // "null"' "$file" 2>&1); then
+    if ! jq_output=$(jq -r '.sandbox.enabled | if . == null then "null" else tostring end' "$file" 2>&1); then
         log_error "jq failed to parse $file: $jq_output"
         echo "unknown"
         return


### PR DESCRIPTION
## Summary

- `speak-sync.sh` の sandbox 検出で jq の `//` 演算子が `false` を `null` と同じ扱いにするバグを修正
- `sandbox.enabled: false` が正しく sandbox 無効として認識されるようになった
- `.sandbox.enabled // "null"` → `.sandbox.enabled | if . == null then "null" else tostring end` に変更

Closes #128

## Test plan

- [ ] `settings.local.json` に `sandbox.enabled: false` を設定し、`/cvi:speak` で音声が再生されることを確認
- [ ] `settings.json` に `sandbox.enabled: true` を設定し、`/cvi:speak` で音声がスキップされることを確認
- [ ] sandbox 設定がない場合、デフォルト動作（sandbox 無効扱い）で音声が再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)