### PR TITLE
fix(code): prevent false positives in PR review gate hook

### DIFF
--- a/plugins/code/scripts/check-pr-review-gate.sh
+++ b/plugins/code/scripts/check-pr-review-gate.sh
@@ -48,8 +48,9 @@ print_diagnostics() {
 INPUT=$(cat)
 COMMAND=$(extract_command "$INPUT")
 
-# Only process gh pr create commands
-if [[ ! "$COMMAND" =~ gh[[:space:]]+pr[[:space:]]+create ]]; then
+# Only process gh pr create commands (match first line only to avoid false positives from heredoc body)
+FIRST_LINE=$(echo "$COMMAND" | head -1)
+if [[ ! "$FIRST_LINE" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- check-pr-review-gate.sh の heredoc/引数内テキスト誤検知を修正
- コマンドの1行目のみを抽出し、行頭アンカー付き正規表現でマッチさせる
- `gh pr edit --body "...PR作成テキスト..."` 等の誤ブロックを解消

## Test plan
- [x] `gh pr edit --body` 内のテキストが誤検知されないこと（exit 0）
- [x] 正規の PR 作成コマンドがブロックされること（exit 2）
- [x] 非関連コマンド（git status等）が通過すること（exit 0）
- [x] 先頭スペース付きPR作成コマンドがブロックされること（exit 2）
- [x] skip-review バイパスが引き続き機能すること

Closes #130

Generated with [Claude Code](https://claude.com/claude-code)