### PR TITLE
chore: add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# GitHub Sponsors
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [dropcontrol, signalcompose]


### PR DESCRIPTION
## Summary

- 個人（`dropcontrol`）と Signal compose org（`signalcompose`）の両方を GitHub Sponsors でサポート
- リポジトリの「Sponsor」ボタンが有効になる（各アカウントの承認後）

## Test plan

- [ ] PR マージ後にリポジトリトップの「Sponsor」ボタンが表示されることを確認
- [ ] dropcontrol / signalcompose それぞれの GitHub Sponsors 申請を完了させる

🤖 Generated with [Claude Code](https://claude.com/claude-code)