### PR TITLE
fix(code): improve shutdown fallback for pr-review-team and refactor-team

### DIFF
--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -85,4 +85,19 @@ Report summary:
 
 **Do NOT merge** — wait for user's explicit instruction.
 
-Send `shutdown_request` to all agents via SendMessage, then TeamDelete.
+### Shutdown Procedure
+
+Send `shutdown_request` to all agents individually via SendMessage (one message per agent):
+- code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, code-fixer
+
+Wait up to 30 seconds for `shutdown_response` from each agent.
+
+Then call TeamDelete.
+
+**If TeamDelete fails** (agents did not respond to shutdown):
+1. Note the team name used in the TeamCreate step
+2. Force-delete team directories using Bash with `dangerouslyDisableSandbox: true`:
+   ```bash
+   rm -rf ~/.claude/teams/<team-name>/ ~/.claude/tasks/<team-name>/
+   ```
+3. Inform user: "Team force-deleted. If agent polling continues, restart Claude Code."

--- a/plugins/code/skills/refactor-team/SKILL.md
+++ b/plugins/code/skills/refactor-team/SKILL.md
@@ -68,4 +68,19 @@ Report summary:
 - Items proposed / approved / completed / failed
 - Commits created
 
-Send `shutdown_request` to all agents via SendMessage, then TeamDelete.
+### Shutdown Procedure
+
+Send `shutdown_request` to all agents individually via SendMessage (one message per agent):
+- analyzer, refactorer
+
+Wait up to 30 seconds for `shutdown_response` from each agent.
+
+Then call TeamDelete.
+
+**If TeamDelete fails** (agents did not respond to shutdown):
+1. Note the team name used in the TeamCreate step
+2. Force-delete team directories using Bash with `dangerouslyDisableSandbox: true`:
+   ```bash
+   rm -rf ~/.claude/teams/<team-name>/ ~/.claude/tasks/<team-name>/
+   ```
+3. Inform user: "Team force-deleted. If agent polling continues, restart Claude Code."


### PR DESCRIPTION
## Summary

- `pr-review-team/SKILL.md` のStep 6シャットダウン手順を拡張し、`shutdown_response` 未返答時のフォールバック処理を追加
- `refactor-team/SKILL.md` にも同様の変更を適用（一貫性確保）
- `TeamDelete` 失敗時に `~/.claude/teams/<name>/` と `~/.claude/tasks/<name>/` を強制削除する手順を明記

## Background

`pr-review-toolkit:*` 系エージェント（silent-failure-hunter、pr-test-analyzer、comment-analyzer）が `shutdown_request` を受信しても `shutdown_response` を返さずにidle状態になる。その結果 `TeamDelete` が失敗し、エージェントのポーリングが継続してしまっていた（ISSUE #146）。

## Test plan

- [ ] `plugins/code/skills/pr-review-team/SKILL.md` のStep 6にShutdown Procedureセクションが追加されていることを確認
- [ ] `plugins/code/skills/refactor-team/SKILL.md` のStep 6にShutdown Procedureセクションが追加されていることを確認
- [ ] 両ファイルのシャットダウン手順が一貫したフォーマットであることを確認
- [ ] フォールバックコマンド（`rm -rf`）のパスが正しいことを確認

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)