### PR TITLE
improve(code): reduce hook context consumption

### DIFF
--- a/plugins/code/scripts/dev-cycle-context-monitor.sh
+++ b/plugins/code/scripts/dev-cycle-context-monitor.sh
@@ -12,6 +12,13 @@ SIDECAR_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/.context-budget.json"
 
 command -v jq &>/dev/null || exit 0
 
+# Throttle: skip if last write was within 30 seconds
+if [[ -f "$SIDECAR_FILE" ]]; then
+  LAST_TS=$(jq -r '.ts // 0' "$SIDECAR_FILE" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  [[ $((NOW - LAST_TS)) -lt 30 ]] && exit 0
+fi
+
 input=$(cat)
 
 REMAINING=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')


### PR DESCRIPTION
## Summary

- フック発火頻度を最適化してコンテキスト消費を削減
- Sandwich Defense の3層構造（compaction 耐性）は完全維持
- 削減したのは構造ではなく発火頻度

Closes #164

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `enforce-code-review-rules.sh` | メッセージフィルタ追加。コードレビュー関連キーワード非一致時は exit 0 |
| `dev-cycle-context-monitor.sh` | 30秒間引き追加。前回書き込みから30秒以内は exit 0 |

### enforce-code-review-rules.sh（推定 ~15,000-30,000 トークン/セッション節約）

- stdin から JSON を読み、`message` フィールドを抽出
- キーワード `review|レビュー|ship|pr|push|commit|shipping|dev.?cycle` に一致しない場合は即 exit 0
- Sandwich Defense の TOP/MIDDLE/BOTTOM 出力は一切変更なし
- JSON パースパターンは `dev-cycle-guard.sh` と同一（既存パターンの踏襲）

### dev-cycle-context-monitor.sh（I/O 負荷削減）

- sidecar ファイルの `ts` を確認し、前回書き込みから30秒以内なら exit 0
- stdin 読み込み前にロジック配置（不要な jq + mktemp + mv をスキップ）
- 30秒間隔はステージ遷移時の予算チェック精度に影響なし

## 妥当性検証

- Codex CLI による5項目の妥当性評価を実施
- キーワードリストの網羅性、stdin 副作用、間引き間隔、配置位置、matcher vs スクリプトフィルタを検証
- 全項目「妥当」と判定

## Test plan

- [x] `bash -n` で両スクリプトの構文検証合格
- [x] G-1: キーワード一致時に Sandwich Defense 出力を確認
- [x] G-2: キーワード非一致時に出力なし（exit 0）を確認
- [x] H-1: 初回書き込み（sidecar なし）が正常動作を確認
- [x] H-2: 30秒以内の重複書き込みがスキップされることを確認
- [x] コードレビュー合格（critical/important 問題なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)