### PR TITLE
refactor(code): redesign pr-review-team with subagents, hooks, and state tracking

### DIFF
--- a/plugins/code/hooks/hooks.json
+++ b/plugins/code/hooks/hooks.json
@@ -10,6 +10,22 @@
             "timeout": 10000
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/scripts/verify-workflow.sh",
+            "timeout": 10000
+          },
+          {
+            "type": "agent",
+            "prompt": "If stop_hook_active is true in the input, exit without blocking. Check if /tmp/claude/pr-review-*.state exists. If no state file exists, exit without blocking (not a PR review session). If state file exists, read it and the transcript at .transcript_path. Verify: (1) The LATEST review iteration shows critical=0 AND important=0, (2) Security checklist was evaluated (security_done=true in state or security-checklist.md in transcript), (3) If fixes were applied, re-review was performed AFTER fixes. If ALL conditions met, exit without blocking. If any condition fails, output {\"decision\":\"block\",\"reason\":\"<what's missing>\"} to block the stop.",
+            "model": "haiku",
+            "timeout": 30000
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -52,6 +68,7 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(gh pr create*)",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-pr-review-gate.sh"
           }
         ]
@@ -61,8 +78,21 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit*)",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-gitignore-security.sh",
             "timeout": 3000
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/reinject-review-context.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -35,22 +35,16 @@ case "$ACTION" in
       exit 1
     fi
     TMP=$(mktemp)
-    trap 'rm -f "$TMP"' EXIT
+    trap 'rm -f "${TMP:-}"' EXIT
     jq --arg k "$KEY" --arg v "$VALUE" \
       '.[$k] = ($v | if . == "true" then true elif . == "false" then false else (try tonumber // .) end)' \
       "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
     echo "State updated: $KEY=$VALUE"
     ;;
-  get)
+  get|verify)
     if [ ! -f "$STATE_FILE" ]; then
-      echo "{}"
-      exit 0
-    fi
-    cat "$STATE_FILE"
-    ;;
-  verify)
-    if [ ! -f "$STATE_FILE" ]; then
-      echo "NO_STATE"
+      # get returns empty JSON; verify returns sentinel string
+      if [ "$ACTION" = "verify" ]; then echo "NO_STATE"; else echo "{}"; fi
       exit 0
     fi
     cat "$STATE_FILE"

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# PR Review State Manager
+# Manages workflow progress in /tmp/claude/pr-review-<PR>.state
+# Also serves as the active-review flag file for Stop hook detection
+
+ACTION="${1:?Usage: pr-review-state.sh <init|set|get|verify|cleanup> [args...]}"
+PR_NUMBER="${2:-unknown}"
+
+# Validate PR_NUMBER is numeric (prevent path traversal)
+if [[ "$PR_NUMBER" != "unknown" ]] && ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: PR_NUMBER must be numeric, got: $PR_NUMBER" >&2
+    exit 1
+fi
+
+STATE_DIR="/tmp/claude"
+STATE_FILE="${STATE_DIR}/pr-review-${PR_NUMBER}.state"
+
+case "$ACTION" in
+  init)
+    mkdir -p "$STATE_DIR"
+    printf '{"pr":"%s","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"iterations":0,"final_critical":-1,"final_important":-1}' "$PR_NUMBER" > "$STATE_FILE"
+    echo "State initialized for PR #$PR_NUMBER"
+    ;;
+  set)
+    KEY="${3:?Missing key}"
+    VALUE="${4:?Missing value}"
+    if [ ! -f "$STATE_FILE" ]; then
+      echo "ERROR: State file not found. Run 'init' first." >&2
+      exit 1
+    fi
+    if ! command -v jq &>/dev/null; then
+      echo "ERROR: jq is required but not found" >&2
+      exit 1
+    fi
+    TMP=$(mktemp)
+    trap 'rm -f "$TMP"' EXIT
+    jq --arg k "$KEY" --arg v "$VALUE" \
+      '.[$k] = ($v | if . == "true" then true elif . == "false" then false else (try tonumber // .) end)' \
+      "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+    echo "State updated: $KEY=$VALUE"
+    ;;
+  get)
+    if [ ! -f "$STATE_FILE" ]; then
+      echo "{}"
+      exit 0
+    fi
+    cat "$STATE_FILE"
+    ;;
+  verify)
+    if [ ! -f "$STATE_FILE" ]; then
+      echo "NO_STATE"
+      exit 0
+    fi
+    cat "$STATE_FILE"
+    ;;
+  cleanup)
+    rm -f "$STATE_FILE"
+    echo "State cleaned up for PR #$PR_NUMBER"
+    ;;
+  *)
+    echo "Unknown action: $ACTION" >&2
+    exit 1
+    ;;
+esac

--- a/plugins/code/scripts/reinject-review-context.sh
+++ b/plugins/code/scripts/reinject-review-context.sh
@@ -17,16 +17,12 @@ if [ "$STATE" = "{}" ]; then
     exit 0
 fi
 
-PR=$(echo "$STATE" | jq -r '.pr // "unknown"' 2>/dev/null)
-PHASE=$(echo "$STATE" | jq -r '.phase // "unknown"' 2>/dev/null)
-ITERATIONS=$(echo "$STATE" | jq -r '.iterations // 0' 2>/dev/null)
+read -r PR PHASE ITERATIONS < <(echo "$STATE" | jq -r '[.pr // "unknown", .phase // "unknown", (.iterations // 0 | tostring)] | @tsv' 2>/dev/null || echo "unknown unknown 0")
 
 cat << EOF
 🔴 PR REVIEW IN PROGRESS (recovered after compaction)
 PR: #$PR | Phase: $PHASE | Iterations: $ITERATIONS
-State file: $STATE_FILE
 Full state: $STATE
 
 Continue the pr-review-team workflow from where you left off.
-Read the state file for details: cat $STATE_FILE
 EOF

--- a/plugins/code/scripts/reinject-review-context.sh
+++ b/plugins/code/scripts/reinject-review-context.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PostCompact hook: Re-inject PR review state into Claude's context
+# Fires after auto-compaction to preserve workflow continuity
+
+shopt -s nullglob
+STATE_FILES=(/tmp/claude/pr-review-*.state)
+shopt -u nullglob
+
+if [ ${#STATE_FILES[@]} -eq 0 ]; then
+    exit 0
+fi
+
+STATE_FILE="${STATE_FILES[0]}"
+STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
+
+if [ "$STATE" = "{}" ]; then
+    exit 0
+fi
+
+PR=$(echo "$STATE" | jq -r '.pr // "unknown"' 2>/dev/null)
+PHASE=$(echo "$STATE" | jq -r '.phase // "unknown"' 2>/dev/null)
+ITERATIONS=$(echo "$STATE" | jq -r '.iterations // 0' 2>/dev/null)
+
+cat << EOF
+🔴 PR REVIEW IN PROGRESS (recovered after compaction)
+PR: #$PR | Phase: $PHASE | Iterations: $ITERATIONS
+State file: $STATE_FILE
+Full state: $STATE
+
+Continue the pr-review-team workflow from where you left off.
+Read the state file for details: cat $STATE_FILE
+EOF

--- a/plugins/code/scripts/wait-ci-checks.sh
+++ b/plugins/code/scripts/wait-ci-checks.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deterministic CI check polling for PR review workflow
+# Returns structured STATUS line: PASS / FAIL / TIMEOUT / ERROR
+
+PR_NUMBER="${1:?Usage: wait-ci-checks.sh <PR_NUMBER>}"
+MAX_ATTEMPTS=3
+WAIT_SECONDS=30
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    echo "=== CI Check Attempt $attempt/$MAX_ATTEMPTS ==="
+
+    CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null) || {
+        echo "STATUS: ERROR (gh command failed — possible TLS/sandbox issue)"
+        echo "ACTION: Use dangerouslyDisableSandbox: true and retry"
+        exit 0
+    }
+
+    echo "$CHECKS"
+    echo ""
+
+    if echo "$CHECKS" | grep -qiE "pending|queued|in_progress"; then
+        if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            echo "PENDING checks found. Waiting ${WAIT_SECONDS}s..."
+            sleep "$WAIT_SECONDS"
+            continue
+        else
+            echo ""
+            echo "STATUS: TIMEOUT"
+            echo "ACTION: Manual verification recommended for pending checks"
+            exit 0
+        fi
+    fi
+
+    if echo "$CHECKS" | grep -qi "fail"; then
+        echo ""
+        echo "STATUS: FAIL"
+        exit 0
+    fi
+
+    echo ""
+    echo "STATUS: PASS"
+    exit 0
+done

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -9,51 +9,59 @@ user-invocable: false
 
 # PR Review Team
 
-**MANDATORY**: This skill runs a complete review-fix-re-review loop. The leader MUST:
-1. Launch reviewers and collect findings (Steps 1-4)
-2. If critical > 0 OR important > 0 OR security != "all_pass": enter fix loop (Step 5)
-3. Iterate until critical = 0 AND important = 0 AND security = "all_pass" (max 5 iterations)
-4. Report results (Step 6)
+**MANDATORY**: This skill runs a complete review-fix-re-review loop using Subagents (NOT Agent Teams).
 
-Stopping after Step 4 without entering the fix loop when issues exist is a violation.
+The leader MUST:
+1. Initialize state and gather PR context (Step 1)
+2. Launch 4 parallel reviewer subagents (Step 2)
+3. Run CI checks via script (Step 3)
+4. Integrate results + security checklist (Step 4)
+5. If critical > 0 OR important > 0 OR security != "all_pass": enter fix loop (Step 5)
+6. Report results and cleanup (Step 6)
 
-## Step 1: Identify Target PR & Detect Project Context
+🔴 Stop hooks verify workflow completion. Skipping steps will block the stop request.
 
-Resolve the PR number:
+## Step 1: Initialize & Identify Target PR
+
+### Initialize State
+
+Run immediately (creates the active-review flag file for Stop hook detection):
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR番号>
+```
+
+### Resolve PR
+
 - If user specified: use that number
-- Otherwise: !`gh pr view --json number --jq '.number' 2>/dev/null`
+- Otherwise: `gh pr view --json number --jq '.number' 2>/dev/null`
 
-Gather context:
-- File overview: `gh pr diff <PR番号> --name-only` (fallback: `git diff <base>...HEAD --name-only`)
+### Gather Context
+
+- File overview: `gh pr diff <PR番号> --name-only`
 - Base branch: `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'` (fallback: `main`)
 - Test command: detect from `package.json`, `Makefile`, `pytest.ini`, etc.
 - Project rules: read project's CLAUDE.md if present
 
 **Note**: `gh` commands may require `dangerouslyDisableSandbox: true` for TLS issues.
 
-## Step 2: Create Review Team
+## Step 2: Parallel Review (Subagents)
 
-**MANDATORY**: Use TeamCreate to create the team, then spawn agents with Task tool.
+**MANDATORY**: Launch ALL 4 reviewers in a SINGLE message using parallel Agent tool calls.
+Do NOT use TeamCreate or Task tool. Use the Agent tool directly.
 
-Team structure:
-```
-Team Lead (yourself)
-├─ Reviewer 1: pr-review-toolkit:code-reviewer
-├─ Reviewer 2: pr-review-toolkit:silent-failure-hunter
-├─ Reviewer 3: pr-review-toolkit:pr-test-analyzer
-├─ Reviewer 4: pr-review-toolkit:comment-analyzer
-└─ Fixer: general-purpose (code-fixer)
-```
+Launch in parallel (one message, 4 Agent tool calls):
 
-Launch all 4 reviewers **in parallel** via Task tool.
+1. `Agent(subagent_type: "pr-review-toolkit:code-reviewer", model: "sonnet", prompt: "...")`
+2. `Agent(subagent_type: "pr-review-toolkit:silent-failure-hunter", model: "sonnet", prompt: "...")`
+3. `Agent(subagent_type: "pr-review-toolkit:pr-test-analyzer", model: "sonnet", prompt: "...")`
+4. `Agent(subagent_type: "pr-review-toolkit:comment-analyzer", model: "haiku", prompt: "...")`
 
-**MANDATORY**: Always specify an explicit `model` parameter when spawning each agent. Choose the appropriate model based on task complexity (`haiku` for lightweight, `sonnet` for standard, `opus` for complex reasoning). Never omit `model` (default `inherit` may fail in parallel spawning).
+Results return automatically. No shutdown procedure needed.
 
-Review criteria: agents read `${CLAUDE_PLUGIN_ROOT}/skills/review-commit/references/review-criteria.md` — leader does NOT read this file (agents handle criteria, leader handles integration).
+Review criteria: include `${CLAUDE_PLUGIN_ROOT}/skills/review-commit/references/review-criteria.md` path in each agent prompt — agents read criteria, leader handles integration.
 
 ### Agent Launch Failure Handling
-
-If any reviewer agent fails to launch:
 
 | Agent | Failure Severity | Action |
 |-------|-----------------|--------|
@@ -62,160 +70,118 @@ If any reviewer agent fails to launch:
 | pr-test-analyzer | WARNING | Continue with remaining reviewers. Note in report. |
 | comment-analyzer | WARNING | Continue with remaining reviewers. Note in report. |
 
-If ALL agents fail: report error and STOP.
-
-## Step 3: Collect CI Results
-
-Leader collects CI data (do NOT delegate):
-
-### Check Status
+### Update State
 
 ```bash
-gh pr checks <PR番号>
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> reviewers_done true
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> phase reviewed
 ```
 
-Parse output for FAIL/PASS/PENDING status per check.
+## Step 3: CI Check
 
-### CI Pending Strategy
+Run the CI wait script (requires `dangerouslyDisableSandbox: true`):
 
-If any checks are PENDING:
-
-```
-FOR attempt = 1 TO 3:
-  1. Wait 30 seconds
-  2. Re-check: gh pr checks <PR番号>
-  3. IF all checks resolved → BREAK
-END FOR
-```
-
-If still PENDING after 3 attempts (90 seconds total):
-- Continue review **without CI results**
-- Add to final report: "CI: PENDING (timed out — manual verification recommended)"
-
-### Get Failure Details
-
-For each failed check:
 ```bash
-# Get failed checks
-gh pr checks <PR番号> --json name,bucket,link --jq '.[] | select(.bucket == "fail")'
-
-# Get failed log
-gh run view <run-id> --log-failed
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh <PR番号>
 ```
 
-### Collect Review Comments
+Parse the STATUS line from output:
+- **PASS**: All checks passed
+- **FAIL**: Get failure details with `gh run view <run-id> --log-failed`
+- **TIMEOUT**: Continue review, note "CI: PENDING (timed out)" in report
+- **ERROR**: Retry with `dangerouslyDisableSandbox: true`
 
+Also collect review comments:
 ```bash
 gh pr view <PR番号> --json comments --jq '.comments[].body'
 ```
 
-Also check for Claude Code review comments (automated review feedback).
-
 ### HEAD Filtering
 
-Avoid sending already-fixed issues to the fixer.
+Avoid sending already-fixed issues to the fixer:
+- For each CI issue or review comment, check if the referenced line still exists in current HEAD
+- Mark modified/removed lines as "already addressed" — do NOT send to fixer
 
+## Step 4: Integrate & Prepare Fixer Message
+
+🔴 VIOLATION — Direct Editing Prohibited
+ALL fixes MUST be delegated to the fixer subagent in Step 5.
+Using Edit/Write tools directly to apply fixes is a workflow violation.
+The Stop hook will block completion if the fixer agent was not used.
+
+🔴 MANDATORY — Security Checklist
+Read NOW (Stop hook verifies this was read):
+`${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/references/security-checklist.md`
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> security_done true
 ```
-FOR each CI issue or review comment:
-  1. Extract the file path and line number from the issue
-  2. Get current diff: gh pr diff <PR番号>
-  3. Check if the referenced line still exists in the current HEAD
-  4. IF the line has been modified or removed since the issue was reported:
-       → Mark as "already addressed" — do NOT send to fixer
-  5. ELSE:
-       → Include in the fixer's issue list
-END FOR
-```
-
-### Sandbox Notes
-
-`gh` commands may fail in sandboxed environments due to TLS certificate restrictions.
-Use `dangerouslyDisableSandbox: true` when calling `gh` via Bash tool.
-This is safe for read-only operations like `gh pr view`, `gh pr checks`, and `gh run view`.
-
-## Step 4: Integrate & Send to Fixer
-
-**MANDATORY**: Combine reviewer results + CI results into **one single message** to fixer.
-Split messages are prohibited (message loss risk).
-
-Security checklist: read `${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/references/security-checklist.md` now (deferred from Step 2 to save context).
 
 ### Fixer Message Template
 
-Structure the message to fixer using this template:
+Structure ALL findings into one single message (split messages prohibited):
 
 ```
 ## Critical Issues
-[List critical issues from all reviewers + CI failures]
 - Source: <reviewer-name>
 - File: <path>:<line>
 - Issue: <description>
 
 ## Important Issues
-[List important issues]
 - Source: <reviewer-name>
 - File: <path>:<line>
 - Issue: <description>
 
 ## Security Checklist Failures
-[List security checklist items that failed]
 - Check: <checklist-item>
 - File: <path>:<line>
 - Issue: <description>
 
 ## Already Addressed (informational — do NOT fix)
-[List issues filtered out by HEAD filtering logic]
 - Source: <reviewer-name or CI>
 - Reason: Line modified/removed in current HEAD
+
+Security Checklist: ALL PASS (N items checked) / HAS FAILURES (list)
 ```
 
-## Step 5: Iterative Fix Loop
+If all pass: "Security Checklist: ALL PASS (N items checked)"
 
-**MANDATORY**: If Step 4 produced ANY critical or important issues, or security checklist failures, this step MUST be executed. Skipping the fix loop and reporting findings without fixing is prohibited.
+## Step 5: Fix Loop
+
+🔴 MANDATORY: If Step 4 produced ANY critical or important issues, or security failures, this step MUST execute.
+
+🔴 VIOLATION — Re-review Required After Fixes
+After fixer applies fixes, ALL 4 reviewers MUST be re-invoked (same parallel pattern as Step 2).
+Skipping re-review is a workflow violation.
 
 ```
-MAX_ITERATIONS=5
-MAX_RETRIES=2
-```
+MAX_ITERATIONS=3
 
-**WARNING: Never use counts from a previous iteration to check the exit condition. Every exit check MUST use counts produced by the re-review in step 4 of the SAME iteration.**
+FOR iteration = 1 TO MAX_ITERATIONS:
+  1. Spawn fixer subagent:
+     Agent(subagent_type: "general-purpose", model: "sonnet", prompt: "<all findings>")
+     Send ALL findings in a single prompt (Critical + Important + Security failures)
 
-```
-FOR iteration = 1 TO $MAX_ITERATIONS:
-  SET fresh_critical = UNSET
-  SET fresh_important = UNSET
-  SET fresh_security = UNSET
-  SET retry_count = 0
-  SET review_retry_count = 0
+  2. Fixer applies fixes and runs tests
+     IF tests fail after 2 retries → report to user, do NOT merge, BREAK
 
-  1. Fixer applies fixes
-  2. Run test command (detected in Step 1)
-  3. IF tests fail:
-       SET retry_count = retry_count + 1
-       IF retry_count >= MAX_RETRIES → report to user ("Test failures persist after MAX_RETRIES retries"), do NOT merge, BREAK outer loop
-       ELSE → Fixer retries (loop back to step 1 of this iteration; do NOT advance to step 4)
-     IF tests pass → CONTINUE to step 4
-  4. Re-review with ALL 4 reviewers in parallel (same failure handling as Step 2):
-     - code-reviewer
-     - silent-failure-hunter
-     - pr-test-analyzer
-     - comment-analyzer
-     ASSIGN fresh_critical, fresh_important, fresh_security FROM this re-review output
-     (fresh_security MUST be one of: "all_pass" or "has_failures". Any other value including empty string is treated as UNSET.)
-  5. Aggregate results (same template as Step 4) using fresh_critical, fresh_important, fresh_security
-  6. MUST VERIFY: fresh_critical, fresh_important, fresh_security are SET (not UNSET).
-     If any is UNSET:
-       SET review_retry_count = review_retry_count + 1
-       IF review_retry_count >= 2 (i.e., any fresh_ variable still remains UNSET after retry), report "Re-review failed" to user and BREAK.
-       ELSE go back to step 4 of THIS iteration (do NOT advance to step 5 or 6; do NOT start a new iteration).
-     IF fresh_critical = 0 AND fresh_important = 0 AND fresh_security = "all_pass":
-       → BREAK
+  3. Re-review: Launch ALL 4 reviewers again (parallel Agent tool calls, same as Step 2)
+
+  4. Collect fresh counts: fresh_critical, fresh_important, fresh_security
+
+  5. Update state:
+     bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> fixer_done true
+     bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> iterations <N>
+     bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> final_critical <count>
+     bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> final_important <count>
+
+  6. IF fresh_critical = 0 AND fresh_important = 0 AND fresh_security = "all_pass" → BREAK
 END FOR
 ```
 
 If iteration limit reached with remaining issues: report to user, do NOT merge.
 
-## Step 6: Report & Shutdown
+## Step 6: Report & Cleanup
 
 Report summary:
 - Issues found / fixed / remaining
@@ -226,20 +192,10 @@ Report summary:
 
 **Do NOT merge** — wait for user's explicit instruction.
 
-### Shutdown Procedure
+### Cleanup
 
-Send `shutdown_request` to all agents individually via SendMessage (one message per agent):
-- code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, code-fixer
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh cleanup <PR番号>
+```
 
-Wait up to 30 seconds for `shutdown_response` from each agent.
-
-Then call TeamDelete.
-
-**If TeamDelete fails** (agents did not respond to shutdown):
-1. Note the team name used in the TeamCreate step (store as `TEAM_NAME`)
-2. Force-delete team directories using Bash with `dangerouslyDisableSandbox: true`:
-   ```bash
-   rm -rf ~/.claude/teams/"${TEAM_NAME:?}"/ ~/.claude/tasks/"${TEAM_NAME:?}"/
-   ```
-   The `${TEAM_NAME:?}` guard prevents `rm -rf` from running with an empty path.
-3. Inform user: "Team force-deleted. If agent polling continues, restart Claude Code."
+No shutdown procedure needed — subagents complete automatically.

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-# Layer 0: Infinite loop prevention (same pattern as CVI/dev-cycle)
+# Infinite loop prevention
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
     exit 0
@@ -26,16 +26,22 @@ fi
 STATE_FILE="${STATE_FILES[0]}"
 STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
 
-# Get transcript path for fallback verification
+# Extract state fields in a single jq call
+read -r SECURITY_DONE FIXER_DONE < <(echo "$STATE" | jq -r '[(.security_done // false | tostring), (.fixer_done // false | tostring)] | @tsv' 2>/dev/null || echo "false false")
+
+# Load transcript once for all checks (avoid repeated file reads)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+TRANSCRIPT=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    TRANSCRIPT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null || true)
+fi
 
 MISSING=""
 
 # Check 1: Security checklist completion
-SECURITY_DONE=$(echo "$STATE" | jq -r '.security_done // false' 2>/dev/null || echo "false")
 if [ "$SECURITY_DONE" != "true" ]; then
-    if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-        if ! grep -q "security-checklist.md" "$TRANSCRIPT_PATH" 2>/dev/null; then
+    if [ -n "$TRANSCRIPT" ]; then
+        if ! echo "$TRANSCRIPT" | grep -q "security-checklist.md" 2>/dev/null; then
             MISSING="${MISSING}\n- Security checklist was not read"
         fi
     else
@@ -44,11 +50,8 @@ if [ "$SECURITY_DONE" != "true" ]; then
 fi
 
 # Check 2: Fixer agent spawned when issues were found
-FIXER_DONE=$(echo "$STATE" | jq -r '.fixer_done // false' 2>/dev/null || echo "false")
-
-# Check transcript for evidence of issues regardless of state counts
-if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-    if grep -qE '"Critical Issues"|"Important Issues"' "$TRANSCRIPT_PATH" 2>/dev/null; then
+if [ -n "$TRANSCRIPT" ]; then
+    if echo "$TRANSCRIPT" | grep -qE '"Critical Issues"|"Important Issues"' 2>/dev/null; then
         if [ "$FIXER_DONE" != "true" ]; then
             MISSING="${MISSING}\n- Fixer agent was not spawned (direct editing is prohibited)"
         fi

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+# PR Review Team - Stop Hook (Command-based)
+# Verifies workflow completion using state file + transcript fallback
+# Part of 5-layer defense: Layer 1 (deterministic gate)
+
+INPUT=$(cat)
+
+# Layer 0: Infinite loop prevention (same pattern as CVI/dev-cycle)
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+    exit 0
+fi
+
+# Session detection via flag file (state file doubles as active-review flag)
+# If no state file exists, this is not a pr-review-team session → pass immediately
+shopt -s nullglob
+STATE_FILES=(/tmp/claude/pr-review-*.state)
+shopt -u nullglob
+if [ ${#STATE_FILES[@]} -eq 0 ]; then
+    exit 0
+fi
+
+# Read progress from state file
+STATE_FILE="${STATE_FILES[0]}"
+STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
+
+# Get transcript path for fallback verification
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+
+MISSING=""
+
+# Check 1: Security checklist completion
+SECURITY_DONE=$(echo "$STATE" | jq -r '.security_done // false' 2>/dev/null || echo "false")
+if [ "$SECURITY_DONE" != "true" ]; then
+    if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+        if ! grep -q "security-checklist.md" "$TRANSCRIPT_PATH" 2>/dev/null; then
+            MISSING="${MISSING}\n- Security checklist was not read"
+        fi
+    else
+        MISSING="${MISSING}\n- Security checklist was not completed (state: security_done=false)"
+    fi
+fi
+
+# Check 2: Fixer agent spawned when issues were found
+FIXER_DONE=$(echo "$STATE" | jq -r '.fixer_done // false' 2>/dev/null || echo "false")
+
+# Check transcript for evidence of issues regardless of state counts
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    if grep -qE '"Critical Issues"|"Important Issues"' "$TRANSCRIPT_PATH" 2>/dev/null; then
+        if [ "$FIXER_DONE" != "true" ]; then
+            MISSING="${MISSING}\n- Fixer agent was not spawned (direct editing is prohibited)"
+        fi
+    fi
+fi
+
+if [ -n "$MISSING" ]; then
+    REASON=$(printf 'PR review workflow incomplete:%b\n\nComplete all required steps before stopping.' "$MISSING")
+    printf '%s' "$REASON" | jq -Rs '{"decision":"block","reason":.}'
+    exit 0
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Agent Teams → Subagents アーキテクチャの全面移行
- 5層防御メカニズム追加（Command Stop hook + Agent Stop hook + PostCompact + VIOLATION ルール + スクリプト自動化）
- PreToolUse hook に `if` フィールド追加で不要なプロセス起動を削減

## 変更内容

### SKILL.md 再設計
- Agent Teams（TeamCreate/Task/SendMessage/TeamDelete）→ Subagents（Agent tool 直接呼び出し）
- シャットダウン手順の完全削除（〜30行削減、Subagents は自動完了）
- Fix Loop: 5→3 イテレーションに簡素化
- State file によるワークフロー進捗追跡

### 新規スクリプト
| スクリプト | 目的 |
|-----------|------|
| `verify-workflow.sh` | Stop hook: フラグファイル方式でセッション判定 + ワークフロー完了検証 |
| `pr-review-state.sh` | State file 管理（init/set/get/verify/cleanup） |
| `wait-ci-checks.sh` | CI ポーリング（max 3回、30秒間隔） |
| `reinject-review-context.sh` | PostCompact: compaction 後の状態復旧 |

### hooks.json
- Stop hook: command（verify-workflow.sh）+ agent（Haiku 意味的検証）の2層
- PostCompact hook: reinject-review-context.sh
- PreToolUse `if` フィールド: `gh pr create*` / `git commit*` のみ発火

## Issue #179 対応マップ

| 問題 | 対策 |
|------|------|
| fixer 未起動 | VIOLATION ルール + Stop hook |
| セキュリティチェックリスト未実施 | MANDATORY ルール + Stop hook |
| 再レビュー未実施 | VIOLATION ルール + Agent Stop hook |
| CI pending 確認不足 | wait-ci-checks.sh |

## コードレビュー

5イテレーションで critical=0, important=0 達成。修正内容:
- sed fallback 削除（jq 必須化）
- nullglob パターン適用
- Stop hook bypass ロジック修正
- JSON 安全エスケープ（jq -Rs）
- Agent hook 応答形式統一
- PR番号バリデーション
- bash 3.2 互換対応
- mktemp クリーンアップ
- jq boolean 型保持
- fixer チェックロジック修正

## 関連

- Closes #179
- 関連: #181 (dev-cycle 改善は別 PR)

## Test plan

- [ ] `pr-review-state.sh init/set/get/verify/cleanup` の各アクション動作確認
- [ ] `verify-workflow.sh` の stop_hook_active=true で即 exit 0
- [ ] `verify-workflow.sh` の state file 不在時に即 exit 0（通常セッション影響なし）
- [ ] `wait-ci-checks.sh` の STATUS 出力確認
- [ ] hooks.json の `if` フィールドで PreToolUse 発火条件が絞り込まれること
- [ ] `/code:pr-review-team` でSubagents が並列起動されること
- [ ] Agent Teams（TeamCreate/TeamDelete）が呼ばれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)