### PR TITLE
Fix lock directory creation in post-speak.sh

### DIFF
--- a/plugins/cvi/scripts/post-speak.sh
+++ b/plugins/cvi/scripts/post-speak.sh
@@ -74,6 +74,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Acquire project-specific lock using mkdir (atomic operation)
 debug_log "Acquiring lock: $LOCK_DIR"
 
+# Ensure parent lock directory exists (may be cleaned on reboot)
+mkdir -p "/tmp/cvi"
+
 # Try to acquire lock (wait up to 30 seconds)
 TIMEOUT=30
 START_TIME=$(date +%s)


### PR DESCRIPTION
## Summary

Ensure the parent lock directory `/tmp/cvi` is created before attempting to acquire the project-specific lock. This prevents failures when the directory has been cleaned (e.g., on system reboot).

## Changes

- Add `mkdir -p "/tmp/cvi"` before lock acquisition to ensure the parent directory exists
- This prevents race conditions and failures when `/tmp` is cleaned between reboots

## Checklist

- [ ] ドキュメントを更新した（該当する場合）
- [ ] marketplace.jsonを更新した（プラグイン追加/変更時）
- [ ] Subtreeが正しく設定されている（プラグイン追加時）

## Related Issues

<!-- 関連するIssueがあればリンク -->

Closes #

https://claude.ai/code/session_01Kz8Sctm646PDH2bv1xzpu5