### PR TITLE
fix(chezmoi): increase default status timeout from 5s to 30s

### DIFF
--- a/plugins/chezmoi/README.md
+++ b/plugins/chezmoi/README.md
@@ -154,7 +154,7 @@ Ensure `~/.config/chezmoi/key.txt` exists and matches the encryption key.
 
 ### chezmoi status timeout
 
-If `chezmoi status` takes longer than expected (default 5 seconds):
+If `chezmoi status` takes longer than expected (default 30 seconds):
 
 **Diagnose the issue**:
 ```

--- a/plugins/chezmoi/README.md
+++ b/plugins/chezmoi/README.md
@@ -169,7 +169,7 @@ This will measure timing for:
 **Increase timeout**:
 ```bash
 # Add to ~/.zshrc
-export CHEZMOI_STATUS_TIMEOUT=10  # seconds
+export CHEZMOI_STATUS_TIMEOUT=60  # seconds
 ```
 
 **Common causes**:

--- a/plugins/chezmoi/commands/diagnose-timeout.md
+++ b/plugins/chezmoi/commands/diagnose-timeout.md
@@ -40,7 +40,7 @@ The diagnostic script measures:
 Bottleneck: Template expansion (1Password/Age)
 
 Recommendations:
-- Increase timeout: export CHEZMOI_STATUS_TIMEOUT=10
+- Increase timeout: export CHEZMOI_STATUS_TIMEOUT=60
 - Optimize 1Password API calls
 - Consider caching template results
 

--- a/plugins/chezmoi/commands/diagnose-timeout.md
+++ b/plugins/chezmoi/commands/diagnose-timeout.md
@@ -35,7 +35,7 @@ The diagnostic script measures:
    → Normal
 
 3. chezmoi status (total): 3.8s
-   → Timeout threshold: 5s
+   → Timeout threshold: 30s
 
 Bottleneck: Template expansion (1Password/Age)
 

--- a/plugins/chezmoi/docs/troubleshooting-timeout.md
+++ b/plugins/chezmoi/docs/troubleshooting-timeout.md
@@ -37,7 +37,7 @@ This measures timing for:
 #### Option A: Increase Timeout (Quick Fix)
 ```bash
 # Add to ~/.zshrc
-export CHEZMOI_STATUS_TIMEOUT=10  # seconds
+export CHEZMOI_STATUS_TIMEOUT=60  # seconds
 ```
 
 #### Option B: Reduce API Calls (Performance Fix)
@@ -76,7 +76,7 @@ export MY_SECRET="value"
 
 #### Option A: Increase Timeout
 ```bash
-export CHEZMOI_STATUS_TIMEOUT=8
+export CHEZMOI_STATUS_TIMEOUT=60
 ```
 
 #### Option B: Optimize Encrypted Files
@@ -148,7 +148,7 @@ EOF
 #### Increase Timeout for Slow Networks
 ```bash
 # Conservative timeout for slow networks
-export CHEZMOI_STATUS_TIMEOUT=15
+export CHEZMOI_STATUS_TIMEOUT=60
 ```
 
 #### Use Offline Mode (Advanced)
@@ -174,13 +174,13 @@ export MY_SECRET=$(op read "op://vault/item/field")
 ### Standard (Balanced)
 ```bash
 # ~/.zshrc
-export CHEZMOI_STATUS_TIMEOUT=8  # Allow some 1Password/Age overhead
+export CHEZMOI_STATUS_TIMEOUT=45  # Allow some 1Password/Age overhead
 ```
 
 ### High Security (Slower)
 ```bash
 # ~/.zshrc
-export CHEZMOI_STATUS_TIMEOUT=15  # Allow extensive 1Password API + Age
+export CHEZMOI_STATUS_TIMEOUT=60  # Allow extensive 1Password API + Age
 ```
 
 ## When Timeout is Normal vs. Concerning

--- a/plugins/chezmoi/docs/troubleshooting-timeout.md
+++ b/plugins/chezmoi/docs/troubleshooting-timeout.md
@@ -4,10 +4,10 @@ This guide helps diagnose and resolve slow `chezmoi status` performance.
 
 ## Overview
 
-The shell sync checker runs `chezmoi status` with a timeout (default: 5 seconds). If the command takes too long, you'll see:
+The shell sync checker runs `chezmoi status` with a timeout (default: 30 seconds). If the command takes too long, you'll see:
 
 ```
-⚠ chezmoi status timed out (>5s)
+⚠ chezmoi status timed out (>30s)
    → Run: /chezmoi:diagnose-timeout to investigate
 ```
 

--- a/plugins/chezmoi/scripts/diagnose-timeout.sh
+++ b/plugins/chezmoi/scripts/diagnose-timeout.sh
@@ -106,7 +106,7 @@ echo ""
 # Recommendations
 echo -e "${CYAN}Recommendations:${NC}"
 if (( $(awk "BEGIN {print ($STATUS_TIME > $TIMEOUT_THRESHOLD)}") )); then
-  echo -e "  • Increase timeout: ${GREEN}export CHEZMOI_STATUS_TIMEOUT=$((TIMEOUT_THRESHOLD + 5))${NC}"
+  echo -e "  • Increase timeout: ${GREEN}export CHEZMOI_STATUS_TIMEOUT=$((TIMEOUT_THRESHOLD * 2))${NC}"
 fi
 
 if (( $(awk "BEGIN {print ($TEMPLATE_TIME > 2.0)}") )); then

--- a/plugins/chezmoi/scripts/diagnose-timeout.sh
+++ b/plugins/chezmoi/scripts/diagnose-timeout.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 CHEZMOI_DIR="$HOME/.local/share/chezmoi"
-TIMEOUT_THRESHOLD=${CHEZMOI_STATUS_TIMEOUT:-5}
+TIMEOUT_THRESHOLD=${CHEZMOI_STATUS_TIMEOUT:-30}
 
 # Color codes
 RED='\033[0;31m'

--- a/plugins/chezmoi/scripts/shell-check.zsh
+++ b/plugins/chezmoi/scripts/shell-check.zsh
@@ -103,7 +103,7 @@ function _chezmoi_check_sync() {
   fi
 
   # Check local changes with timeout (configurable via CHEZMOI_STATUS_TIMEOUT)
-  local timeout_seconds=${CHEZMOI_STATUS_TIMEOUT:-5}
+  local timeout_seconds=${CHEZMOI_STATUS_TIMEOUT:-30}
   local chezmoi_output chezmoi_exit
   local -a chezmoi_status_cmd=(chezmoi status)
   if command -v timeout &>/dev/null; then
@@ -146,7 +146,7 @@ function _chezmoi_check_sync() {
     }
     $has_status_timeout && {
       print -P "  %F{yellow}⚠%f Sync status unknown (timeout)"
-      print -P "    → Increase timeout: %F{green}export CHEZMOI_STATUS_TIMEOUT=10%f"
+      print -P "    → Increase timeout: %F{green}export CHEZMOI_STATUS_TIMEOUT=60%f"
     }
     print -P "%F{yellow}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━%f"
   else


### PR DESCRIPTION
## Summary
- chezmoi statusのデフォルトタイムアウトを5秒から30秒に引き上げ
- 1Password API / Age復号を使用する環境でのタイムアウト発生を軽減
- ドキュメント・診断スクリプトの全タイムアウト値を新デフォルトに合わせて更新

## Test plan
- [ ] 新しいシェルを開き、chezmoi statusチェックがタイムアウトしないことを確認
- [ ] `CHEZMOI_STATUS_TIMEOUT=1` で明示的にタイムアウトを発生させ、案内メッセージが `60` と表示されることを確認
- [ ] `/chezmoi:diagnose-timeout` でデフォルト閾値が30秒と表示されることを確認
- [ ] ドキュメント内に旧デフォルト値（5秒）の参照が残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)