### PR TITLE
feat(code): add deny list to plugin settings for safer autonomous runs

### DIFF
--- a/plugins/code/.claude/settings.json
+++ b/plugins/code/.claude/settings.json
@@ -14,6 +14,14 @@
       "Bash(git add *)",
       "Bash(git commit *)",
       "Edit(**)"
+    ],
+    "deny": [
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(sudo *)",
+      "Bash(chmod 777 *)",
+      "Read(./.env)",
+      "Read(./.env.*)"
     ]
   }
 }

--- a/plugins/code/.claude/settings.json
+++ b/plugins/code/.claude/settings.json
@@ -16,10 +16,10 @@
       "Edit(**)"
     ],
     "deny": [
-      "Bash(git push --force *)",
-      "Bash(git push -f *)",
-      "Bash(sudo *)",
-      "Bash(chmod 777 *)",
+      "Bash(git push --force :*)",
+      "Bash(git push -f :*)",
+      "Bash(sudo :*)",
+      "Bash(chmod 777 :*)",
       "Read(./.env)",
       "Read(./.env.*)"
     ]


### PR DESCRIPTION
## 概要

自律実行される dev-cycle workflow で破壊的操作を防ぐため、code プラグイン同梱の `.claude/settings.json` に `deny` リストを追加する。

## 背景

- `settings.local.json` が 100〜230 個の allow で肥大化する傾向があり、個人設定に依存して dev-cycle を回している。
- 一方で `deny` はほとんど定義されておらず、危険操作に対するガードが弱い。
- Claude Code の permissions 仕様では `deny > ask > allow` で評価されるため、既存の allow を変えずに危険操作だけを確実に止められる。

## 変更内容

`plugins/code/.claude/settings.json` の `permissions` に `deny` を追加:

| Pattern | 目的 |
|---------|------|
| `Bash(git push --force :*)` / `Bash(git push -f :*)` | force push 防止 (`--force-with-lease` は空白境界で対象外、flag 後置形 `git push ... --force` は別途検討) |
| `Bash(sudo :*)` | 権限昇格防止 |
| `Bash(chmod 777 :*)` | `chmod 777` 直接指定形式のみ防止 (`chmod 0777` / `chmod a+rwx` / `chmod -R 777` 等の equivalent は別途検討) |
| `Read(./.env)` / `Read(./.env.*)` | プロジェクト root の `.env` シークレット漏洩防止 (subdirectory `.env` は別途検討) |

> パターン構文は `:*` (colon-asterisk) に統一。project root `.claude/settings.json` の既存 deny 群と同じ規則。

## 設計判断

- **保守的な最小セット**: `rm -rf *` や `git reset --hard *` は dev 操作で legitimate に使われるため含めない。
- **`--force-with-lease` は許可**: プロジェクト CLAUDE.md に沿って、`git rebase` 後の明示的使用を妨げない。
- **Read deny は `./` 相対限定**: tilde (`~`) 展開の信頼性が Claude Code docs で保証されていないため、絶対パス形式の利用は避けた。

## レビュープロセス

`/code:review-commit` による iterative review (2 iterations):
- Iteration 1: 3 件の important issue 指摘 (`rm -rf`, `git reset --hard`, `~/.ssh` の過剰/不確実な deny)
- Iteration 2: 指摘反映後、critical=0 important=0 minor=0

## Test plan

- [ ] このプラグインを読み込んでいる既存プロジェクトで dev-cycle を実行し、deny が想定通り（force push のみ止まる、通常 push は通る）動作することを手動確認
- [ ] `.env` 読み取りが実際にブロックされることを確認
- [ ] `--force-with-lease` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
