### PR TITLE
feat: add /code:autopilot pipeline, /code:plan wrapper, and setup-dev-env 3-layer triage

### DIFF
--- a/plugins/code/commands/autopilot.md
+++ b/plugins/code/commands/autopilot.md
@@ -19,17 +19,27 @@ auto mode 前提のフルパイプライン orchestrator。プラン承認から
 
 ## パイプライン
 
+実行フェーズ（`.claude/autopilot.state.json` の `.phase` フィールド）:
+
 ```
-Stage 0: Auto mode 検出 + State 初期化
-Stage 1: sprint-impl        (実装、per-module commit)
-Stage 2: audit-compliance   (DDD/TDD/DRY/ISSUE/PROCESS)
-Stage 3: simplify           (built-in /simplify、3 agents 並列レビュー)
-Stage 3.5: ensure-issue     (plan.issue が null なら gh issue create)
-Stage 4: shipping-pr        (--skip-review で commit + push + PR 作成)
-Stage 5: pr-review-team     (CI 待機 + 4 agents + iterate)
-Stage 6: retrospective      (学習記録、Serena memory 保存)
-Stage 7: Ready-to-merge で停止 (マージは user 指示待ち)
+Prep:  Auto mode 検出 + state 初期化 + ensure-issue (plan.issue が null なら gh issue create)
+  ↓
+sprint          (code:sprint-impl — 実装、per-module commit)
+  ↓
+audit           (code:audit-compliance — DDD/TDD/DRY/ISSUE/PROCESS)
+  ↓
+simplify        (simplify — 3 agents 並列レビュー、critical+important=0 まで iterate)
+  ↓
+ship            (code:shipping-pr --skip-review — commit/push/PR 作成、simplify 収束後のみ)
+  ↓
+post-pr-review  (code:pr-review-team — CI 待機 + 4 agents + iterate)
+  ↓
+retrospective   (code:retrospective — 学習記録、Serena memory 保存)
+  ↓
+complete        (Ready-to-merge で停止、マージは user 指示待ち)
 ```
+
+`ensure-issue` は phase ではなく Prep 内の一括処理として実行される。
 
 停止条件: `critical + important = 0` AND `security pass` AND `CI SUCCESS`
 

--- a/plugins/code/commands/autopilot.md
+++ b/plugins/code/commands/autopilot.md
@@ -1,0 +1,48 @@
+---
+description: auto mode 前提のフルパイプライン orchestrator (sprint → audit → simplify → ship → review → retro)
+argument-hint: [plan-file | "description" | Issue N 参照]
+---
+
+# /code:autopilot
+
+auto mode 前提のフルパイプライン orchestrator。プラン承認から PR Ready-to-merge までを自動連鎖する。
+
+## 使い方
+
+```
+/code:autopilot /abs/path/to/plan.md             # plan file から起動
+/code:autopilot "shipping-pr に skip_review..."   # 自然言語 description
+/code:autopilot Issue 123 を実装                   # GitHub Issue を自然言語で参照
+```
+
+引数は自然言語で判別します（明示 flag は不要）。
+
+## パイプライン
+
+```
+Stage 0: Auto mode 検出 + State 初期化
+Stage 1: sprint-impl        (実装、per-module commit)
+Stage 2: audit-compliance   (DDD/TDD/DRY/ISSUE/PROCESS)
+Stage 3: simplify           (built-in /simplify、3 agents 並列レビュー)
+Stage 3.5: ensure-issue     (plan.issue が null なら gh issue create)
+Stage 4: shipping-pr        (--skip-review で commit + push + PR 作成)
+Stage 5: pr-review-team     (CI 待機 + 4 agents + iterate)
+Stage 6: retrospective      (学習記録、Serena memory 保存)
+Stage 7: Ready-to-merge で停止 (マージは user 指示待ち)
+```
+
+停止条件: `critical + important = 0` AND `security pass` AND `CI SUCCESS`
+
+## Auto mode 非対応時
+
+`autopilot-detect-auto-mode.sh` で auto mode を検出できなかった場合、refuse して以下を案内:
+
+1. `claude --permission-mode auto` で再起動
+2. settings.json に `permissions.defaultMode: "auto"` を追加
+3. auto mode 不要なら `/code:dev-cycle` を使用
+
+## 関連
+
+- `/code:plan` — autopilot 強制 directive を注入する plan 作成ラッパー
+- `/code:dev-cycle` — auto mode 非対応時の legacy パイプライン
+- `/code:shipping-pr` — `--skip-review` フラグで個別起動可能

--- a/plugins/code/commands/plan.md
+++ b/plugins/code/commands/plan.md
@@ -1,0 +1,58 @@
+---
+description: built-in /plan の薄いラッパー。autopilot 強制 directive を注入して pipeline 起動を保証
+argument-hint: [description or issue reference]
+---
+
+# /code:plan
+
+`/code:plan` は built-in `/plan` mode の薄いラッパーで、plan file の先頭に **autopilot 強制 directive** を注入します。この directive により、ExitPlanMode で承認された plan は Claude が自動で `/code:autopilot` 経由で実装するようになります。
+
+## 使い方
+
+```
+/code:plan                                 # 会話履歴から synthesis
+/code:plan "shipping-pr に skip_review..."  # 自然言語の description から
+/code:plan Issue 195 のプラン書いて          # GitHub Issue から synthesis
+/code:plan 今までの内容でプランを作って       # 会話履歴から synthesis
+```
+
+引数の判別は Claude が自然言語で解釈します（明示的な flag は不要）。
+
+## built-in `/plan` との違い
+
+| 項目 | built-in `/plan` | `/code:plan` |
+|------|----------------|-------------|
+| plan file 作成 | ✅ | ✅ |
+| ExitPlanMode 承認 | ✅ | ✅ |
+| Explore 連携 | ✅ | ✅ |
+| **autopilot 強制 directive** | ❌ | ✅（決定的な差）|
+| 承認後の挙動 | Claude が直接実装 | Claude が `/code:autopilot` を自動起動 → pipeline 実行 |
+
+## 動作フロー
+
+1. built-in plan mode に入る（`EnterPlanMode` 相当）
+2. 引数から意図を解釈（description / Issue 参照 / 会話履歴 / 無引数）
+3. Explore + synthesis を経て plan file を作成
+4. **plan file 先頭に autopilot directive を注入**:
+   ```
+   🔴 MANDATORY: このプランは auto mode で `/code:autopilot` により実装すること。
+   手動実装禁止。起動コマンド: `/code:autopilot <plan-file>`
+   ```
+5. `ExitPlanMode` で user approval
+6. 承認後、directive により Claude が自動で `/code:autopilot <plan-file>` を起動
+
+## いつ使うべきか
+
+- autopilot pipeline（sprint → audit → simplify → ship → review → retro）を通したい時
+- PR-ready までの品質ゲートを自動化したい時
+- 会話で議論した内容を pipeline に流し込みたい時
+
+## 使うべきでないケース
+
+- autopilot pipeline 不要な単発修正 → built-in `/plan` を使う
+- 既に plan file がある → 直接 `/code:autopilot <plan-file>` を呼ぶ
+
+## 関連
+
+- `/code:autopilot` — plan directive が起動する pipeline orchestrator
+- `/plan` (built-in) — autopilot を通さない汎用 plan mode

--- a/plugins/code/hooks/hooks.json
+++ b/plugins/code/hooks/hooks.json
@@ -20,6 +20,16 @@
             "timeout": 10000
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-stop.sh",
+            "timeout": 10000
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/plugins/code/scripts/autopilot-detect-auto-mode.sh
+++ b/plugins/code/scripts/autopilot-detect-auto-mode.sh
@@ -39,28 +39,27 @@ get_field() {
   jq -r "$path // empty" "$file" 2>/dev/null || return 1
 }
 
-# First check disable conditions across all layers
-for f in \
-  "${PROJECT_DIR}/.claude/settings.json" \
-  "${PROJECT_DIR}/.claude/settings.local.json" \
-  "${HOME}/.claude/settings.json"
-do
-  disable=$(get_field "$f" '.permissions.disableAutoMode')
-  if [ "$disable" = "disable" ]; then
-    echo "disabled"
-    exit 1
-  fi
-done
-
-# 2–4. Scan layers for defaultMode == "auto"
-for f in \
+# Single-pass scan across all layers: read disable + mode in one jq call per file.
+#
+# `permissions.disableAutoMode == "disable"` is a managed-settings convention (may be
+# organization-level only) — the check is defensive; if the field never appears,
+# the disable branch simply never fires.
+for entry in \
   "${PROJECT_DIR}/.claude/settings.json:project" \
   "${PROJECT_DIR}/.claude/settings.local.json:local" \
   "${HOME}/.claude/settings.json:user"
 do
-  path="${f%%:*}"
-  label="${f##*:}"
-  mode=$(get_field "$path" '.permissions.defaultMode')
+  path="${entry%%:*}"
+  label="${entry##*:}"
+  [ -f "$path" ] || continue
+  # Read both fields in a single jq invocation: "<disable>|<defaultMode>"
+  pair=$(jq -r '"\(.permissions.disableAutoMode // "")|\(.permissions.defaultMode // "")"' "$path" 2>/dev/null || echo "|")
+  disable="${pair%%|*}"
+  mode="${pair##*|}"
+  if [ "$disable" = "disable" ]; then
+    echo "disabled"
+    exit 1
+  fi
   if [ "$mode" = "auto" ]; then
     echo "$label"
     exit 0

--- a/plugins/code/scripts/autopilot-detect-auto-mode.sh
+++ b/plugins/code/scripts/autopilot-detect-auto-mode.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# autopilot-detect-auto-mode.sh — Detect whether Claude Code is in auto mode.
+#
+# Usage: autopilot-detect-auto-mode.sh
+#
+# Detection order (first hit wins, exits 0 with the source on stdout):
+#   1. Explicit opt-in flag:  .claude/autopilot.auto-mode-confirmed exists
+#   2. Project settings:      .claude/settings.json permissions.defaultMode == "auto"
+#   3. Project local:         .claude/settings.local.json permissions.defaultMode == "auto"
+#   4. User global:           ~/.claude/settings.json permissions.defaultMode == "auto"
+#
+# Disable conditions (any match -> exit 1, "disabled" on stdout):
+#   - any of the scanned settings has permissions.disableAutoMode == "disable"
+#
+# Exit codes:
+#   0 — auto mode detected (source echoed to stdout)
+#   1 — auto mode disabled by managed setting
+#   2 — auto mode not detected
+#
+# No side effects. Read-only scan.
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || { echo "autopilot-detect: jq required" >&2; exit 2; }
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+OPT_IN_FLAG="${PROJECT_DIR}/.claude/autopilot.auto-mode-confirmed"
+
+# 1. Opt-in flag
+if [ -f "$OPT_IN_FLAG" ]; then
+  echo "opt-in-flag"
+  exit 0
+fi
+
+# Helper: read a JSON field safely
+get_field() {
+  local file="$1" path="$2"
+  [ -f "$file" ] || return 1
+  jq -r "$path // empty" "$file" 2>/dev/null || return 1
+}
+
+# First check disable conditions across all layers
+for f in \
+  "${PROJECT_DIR}/.claude/settings.json" \
+  "${PROJECT_DIR}/.claude/settings.local.json" \
+  "${HOME}/.claude/settings.json"
+do
+  disable=$(get_field "$f" '.permissions.disableAutoMode')
+  if [ "$disable" = "disable" ]; then
+    echo "disabled"
+    exit 1
+  fi
+done
+
+# 2–4. Scan layers for defaultMode == "auto"
+for f in \
+  "${PROJECT_DIR}/.claude/settings.json:project" \
+  "${PROJECT_DIR}/.claude/settings.local.json:local" \
+  "${HOME}/.claude/settings.json:user"
+do
+  path="${f%%:*}"
+  label="${f##*:}"
+  mode=$(get_field "$path" '.permissions.defaultMode')
+  if [ "$mode" = "auto" ]; then
+    echo "$label"
+    exit 0
+  fi
+done
+
+# Not detected
+echo "not-detected"
+exit 2

--- a/plugins/code/scripts/autopilot-detect-auto-mode.sh
+++ b/plugins/code/scripts/autopilot-detect-auto-mode.sh
@@ -52,8 +52,12 @@ do
   path="${entry%%:*}"
   label="${entry##*:}"
   [ -f "$path" ] || continue
-  # Read both fields in a single jq invocation: "<disable>|<defaultMode>"
-  pair=$(jq -r '"\(.permissions.disableAutoMode // "")|\(.permissions.defaultMode // "")"' "$path" 2>/dev/null || echo "|")
+  # Read both fields in a single jq invocation. Distinguish jq parse errors
+  # (malformed JSON) from "field absent" so users get actionable guidance.
+  if ! pair=$(jq -r '"\(.permissions.disableAutoMode // "")|\(.permissions.defaultMode // "")"' "$path" 2>/dev/null); then
+    echo "autopilot-detect: warning: $path is malformed JSON; skipping" >&2
+    continue
+  fi
   disable="${pair%%|*}"
   mode="${pair##*|}"
   if [ "$disable" = "disable" ]; then

--- a/plugins/code/scripts/autopilot-ensure-issue.sh
+++ b/plugins/code/scripts/autopilot-ensure-issue.sh
@@ -13,10 +13,10 @@
 #       → If CLOSED or missing: exit 1 with error.
 #   - Emits the resolved issue number on stdout.
 #
-# Requires: yq (v4+), gh, jq.
+# Requires: gh, jq, awk (all standard).
 # Exit codes:
 #   0 — OK, issue number on stdout
-#   1 — referenced issue is closed or missing
+#   1 — referenced issue is closed or missing, or plan update failed post-create
 #   2 — usage error / dependency missing
 
 set -euo pipefail
@@ -70,14 +70,30 @@ if [ -z "$title" ]; then
 fi
 [ -n "$title" ] || die "could not derive title from plan" 2
 
-# Body: strip the MANDATORY autopilot directive block and frontmatter before posting.
+# Body: strip the MANDATORY autopilot directive block and YAML frontmatter before posting.
 # The directive is an internal routing signal; the GitHub issue should carry only
 # the human-readable content (Goal, Acceptance, Files, Test Strategy, Risks, References).
+#
+# State machine handles the canonical plan structure:
+#   [directive: "🔴 MANDATORY..." ending with "---"]
+#   [optional frontmatter: "---...---"]
+#   [content]
+#
+# States: print (default) → skip_directive (hit 🔴) → post_directive (hit dir's ---)
+#         → skip_frontmatter (hit opening ---) OR print (non-dash content line)
+#         → print (hit closing ---)
 body=$(awk '
-  /^🔴 \*\*MANDATORY\*\*/{skip_directive=1; next}
-  skip_directive && /^---$/{skip_directive=0; in_frontmatter=1; next}
-  in_frontmatter && /^---$/{in_frontmatter=0; next}
-  !skip_directive && !in_frontmatter{print}
+  BEGIN { mode="print" }
+  mode=="print" && /^🔴 \*\*MANDATORY\*\*/  { mode="skip_directive"; next }
+  mode=="skip_directive" && /^---$/          { mode="post_directive"; next }
+  mode=="skip_directive"                     { next }
+  # post_directive: blank lines between directive end and frontmatter start are skipped.
+  mode=="post_directive" && /^[[:space:]]*$/ { next }
+  mode=="post_directive" && /^---$/          { mode="skip_frontmatter"; next }
+  mode=="post_directive"                     { mode="print"; print; next }
+  mode=="skip_frontmatter" && /^---$/        { mode="print"; next }
+  mode=="skip_frontmatter"                   { next }
+  mode=="print"                              { print }
 ' "$PLAN")
 
 # If the directive/frontmatter strip resulted in an empty body, fall back to full content.
@@ -93,21 +109,32 @@ new_num=$(echo "$url" | grep -oE '[0-9]+$')
 [ -n "$new_num" ] || die "failed to parse issue number from: $url"
 
 # Update plan frontmatter: set issue: <new_num>. Use trap-tracked temp file.
+# If this step fails after gh issue create, we must NOT silently leak the new issue number.
 TMP_PLAN=$(mktemp)
-# Detect whether the frontmatter already contains an issue line
 has_issue=$(echo "$frontmatter" | awk '/^issue:/{found=1} END{print found+0}')
+update_ok=0
 if [ "$has_issue" = "1" ]; then
   awk -v num="$new_num" '
     /^---$/{count++; print; next}
     count==1 && /^issue:/{print "issue: " num; updated=1; next}
     {print}
     END{if (!updated) exit 2}
-  ' "$PLAN" > "$TMP_PLAN" && mv "$TMP_PLAN" "$PLAN" && TMP_PLAN=""
+  ' "$PLAN" > "$TMP_PLAN" && update_ok=1
 else
   awk -v num="$new_num" '
     /^---$/{count++; print; if (count==1) print "issue: " num; next}
     {print}
-  ' "$PLAN" > "$TMP_PLAN" && mv "$TMP_PLAN" "$PLAN" && TMP_PLAN=""
+  ' "$PLAN" > "$TMP_PLAN" && update_ok=1
+fi
+
+if [ "$update_ok" = "1" ]; then
+  mv "$TMP_PLAN" "$PLAN"
+  TMP_PLAN=""
+else
+  echo "autopilot-ensure-issue: WARNING: issue #$new_num was created on GitHub but the plan file" >&2
+  echo "  could not be updated with the link. Manual fix required: add 'issue: $new_num' to the" >&2
+  echo "  frontmatter of $PLAN, or re-run this script after fixing the frontmatter format." >&2
+  exit 1
 fi
 
 echo "$new_num"

--- a/plugins/code/scripts/autopilot-ensure-issue.sh
+++ b/plugins/code/scripts/autopilot-ensure-issue.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# autopilot-ensure-issue.sh — Ensure the plan has a linked OPEN GitHub Issue.
+#
+# Usage: autopilot-ensure-issue.sh <plan-file>
+#
+# Behavior:
+#   - Reads YAML frontmatter `issue` field from the plan file.
+#   - If `issue` is null or missing:
+#       → Create a new issue via `gh issue create` using plan Goal as title
+#         and the full plan as body; update plan frontmatter with the new number.
+#   - If `issue` is a number:
+#       → Verify via `gh issue view <N> --json state`. Must be OPEN.
+#       → If CLOSED or missing: exit 1 with error.
+#   - Emits the resolved issue number on stdout.
+#
+# Requires: yq (v4+), gh, jq.
+# Exit codes:
+#   0 — OK, issue number on stdout
+#   1 — referenced issue is closed or missing
+#   2 — usage error / dependency missing
+
+set -euo pipefail
+
+die() { echo "autopilot-ensure-issue: $*" >&2; exit "${2:-1}"; }
+
+command -v gh >/dev/null 2>&1 || die "gh CLI required" 2
+command -v jq >/dev/null 2>&1 || die "jq required" 2
+
+PLAN="${1:-}"
+[ -n "$PLAN" ] || die "usage: autopilot-ensure-issue.sh <plan-file>" 2
+[ -f "$PLAN" ] || die "plan file not found: $PLAN" 2
+
+# Read frontmatter block (between first two --- markers)
+frontmatter=$(awk '/^---$/{count++; if (count==2) exit; next} count==1' "$PLAN")
+
+issue_line=$(echo "$frontmatter" | grep -E '^issue:' || true)
+issue_raw=$(echo "$issue_line" | sed -E 's/^issue:[[:space:]]*//' | tr -d '[:space:]')
+
+# Normalize null/empty
+case "$issue_raw" in
+  ""|null|None|nil) issue="" ;;
+  *) issue="$issue_raw" ;;
+esac
+
+if [ -n "$issue" ]; then
+  # Validate OPEN
+  state=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null || true)
+  if [ -z "$state" ]; then
+    die "issue #$issue not found"
+  fi
+  if [ "$state" != "OPEN" ]; then
+    die "issue #$issue is $state, not OPEN — human review needed"
+  fi
+  echo "$issue"
+  exit 0
+fi
+
+# Create new issue from plan
+# Title: first H1 or derived from Goal section, max 70 chars
+title=$(awk '/^## Goal/{flag=1; next} /^## /{flag=0} flag && NF{print; exit}' "$PLAN" \
+        | sed -E 's/^[-*][[:space:]]*//' | head -c 70)
+if [ -z "$title" ]; then
+  # Fallback: first H1 from file
+  title=$(grep -m1 -E '^# ' "$PLAN" | sed -E 's/^#[[:space:]]*//' | head -c 70)
+fi
+[ -n "$title" ] || die "could not derive title from plan" 2
+
+# Body: full plan content (strip the directive block marker since Issue shouldn't duplicate it)
+body=$(cat "$PLAN")
+
+# Create issue
+url=$(gh issue create --title "$title" --body "$body" --label enhancement 2>&1 | tail -1)
+new_num=$(echo "$url" | grep -oE '[0-9]+$')
+[ -n "$new_num" ] || die "failed to parse issue number from: $url"
+
+# Update plan frontmatter: set issue: <new_num>
+# Use sed to replace 'issue: null' or missing issue line with new number
+if grep -qE '^issue:' "$PLAN"; then
+  # Replace existing issue line inside frontmatter only (first occurrence after first ---)
+  awk -v num="$new_num" '
+    /^---$/{count++; print; next}
+    count==1 && /^issue:/{print "issue: " num; updated=1; next}
+    {print}
+    END{if (!updated) exit 2}
+  ' "$PLAN" > "$PLAN.tmp" && mv "$PLAN.tmp" "$PLAN"
+else
+  # Inject into frontmatter (after first --- line)
+  awk -v num="$new_num" '
+    /^---$/{count++; print; if (count==1) print "issue: " num; next}
+    {print}
+  ' "$PLAN" > "$PLAN.tmp" && mv "$PLAN.tmp" "$PLAN"
+fi
+
+echo "$new_num"

--- a/plugins/code/scripts/autopilot-ensure-issue.sh
+++ b/plugins/code/scripts/autopilot-ensure-issue.sh
@@ -30,11 +30,16 @@ PLAN="${1:-}"
 [ -n "$PLAN" ] || die "usage: autopilot-ensure-issue.sh <plan-file>" 2
 [ -f "$PLAN" ] || die "plan file not found: $PLAN" 2
 
-# Read frontmatter block (between first two --- markers)
+# Temp file cleanup on any exit
+TMP_PLAN=""
+cleanup() { [ -n "$TMP_PLAN" ] && rm -f "$TMP_PLAN"; }
+trap cleanup EXIT
+
+# Read frontmatter block (between first two --- markers) - scoped lookup only
 frontmatter=$(awk '/^---$/{count++; if (count==2) exit; next} count==1' "$PLAN")
 
-issue_line=$(echo "$frontmatter" | grep -E '^issue:' || true)
-issue_raw=$(echo "$issue_line" | sed -E 's/^issue:[[:space:]]*//' | tr -d '[:space:]')
+# Look up `issue:` only inside frontmatter (prevents false match on body text)
+issue_raw=$(echo "$frontmatter" | awk '/^issue:/{sub(/^issue:[[:space:]]*/,""); print; exit}' | tr -d '[:space:]')
 
 # Normalize null/empty
 case "$issue_raw" in
@@ -65,30 +70,44 @@ if [ -z "$title" ]; then
 fi
 [ -n "$title" ] || die "could not derive title from plan" 2
 
-# Body: full plan content (strip the directive block marker since Issue shouldn't duplicate it)
-body=$(cat "$PLAN")
+# Body: strip the MANDATORY autopilot directive block and frontmatter before posting.
+# The directive is an internal routing signal; the GitHub issue should carry only
+# the human-readable content (Goal, Acceptance, Files, Test Strategy, Risks, References).
+body=$(awk '
+  /^🔴 \*\*MANDATORY\*\*/{skip_directive=1; next}
+  skip_directive && /^---$/{skip_directive=0; in_frontmatter=1; next}
+  in_frontmatter && /^---$/{in_frontmatter=0; next}
+  !skip_directive && !in_frontmatter{print}
+' "$PLAN")
 
-# Create issue
-url=$(gh issue create --title "$title" --body "$body" --label enhancement 2>&1 | tail -1)
+# If the directive/frontmatter strip resulted in an empty body, fall back to full content.
+[ -n "$body" ] || body=$(cat "$PLAN")
+
+# Create issue (label is optional - omit if repository lacks it)
+gh_args=(--title "$title" --body "$body")
+if gh label list --limit 50 --json name --jq '.[].name' 2>/dev/null | grep -qx enhancement; then
+  gh_args+=(--label enhancement)
+fi
+url=$(gh issue create "${gh_args[@]}" 2>&1 | tail -1)
 new_num=$(echo "$url" | grep -oE '[0-9]+$')
 [ -n "$new_num" ] || die "failed to parse issue number from: $url"
 
-# Update plan frontmatter: set issue: <new_num>
-# Use sed to replace 'issue: null' or missing issue line with new number
-if grep -qE '^issue:' "$PLAN"; then
-  # Replace existing issue line inside frontmatter only (first occurrence after first ---)
+# Update plan frontmatter: set issue: <new_num>. Use trap-tracked temp file.
+TMP_PLAN=$(mktemp)
+# Detect whether the frontmatter already contains an issue line
+has_issue=$(echo "$frontmatter" | awk '/^issue:/{found=1} END{print found+0}')
+if [ "$has_issue" = "1" ]; then
   awk -v num="$new_num" '
     /^---$/{count++; print; next}
     count==1 && /^issue:/{print "issue: " num; updated=1; next}
     {print}
     END{if (!updated) exit 2}
-  ' "$PLAN" > "$PLAN.tmp" && mv "$PLAN.tmp" "$PLAN"
+  ' "$PLAN" > "$TMP_PLAN" && mv "$TMP_PLAN" "$PLAN" && TMP_PLAN=""
 else
-  # Inject into frontmatter (after first --- line)
   awk -v num="$new_num" '
     /^---$/{count++; print; if (count==1) print "issue: " num; next}
     {print}
-  ' "$PLAN" > "$PLAN.tmp" && mv "$PLAN.tmp" "$PLAN"
+  ' "$PLAN" > "$TMP_PLAN" && mv "$TMP_PLAN" "$PLAN" && TMP_PLAN=""
 fi
 
 echo "$new_num"

--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -110,17 +110,22 @@ cmd_set() {
   local key="$1" value="$2"
   [ -n "$key" ] && [ -n "${value+x}" ] || die "usage: set <key> <value>"
   [ -f "$STATE_FILE" ] || die "no state file; run init first"
+  # Reject keys containing shell/jq metacharacters (defense against injection via arg)
+  [[ "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid key: $key"
   local now; now=$(iso_now)
   local tmp; tmp=$(mktemp)
-  # Always try to parse value as JSON; fall back to string
-  if jq -e ".$key = $value" "$STATE_FILE" >"$tmp" 2>/dev/null; then
+  # Prefer --argjson (typed JSON). Fall back to --arg (string) if value is not valid JSON.
+  # Single-pass write that also stamps updated_at; no secondary jq call.
+  if jq --arg key "$key" --argjson v "$value" --arg now "$now" \
+        '.[$key] = $v | .updated_at = $now' \
+        "$STATE_FILE" >"$tmp" 2>/dev/null; then
     :
   else
-    jq ".$key = \$v | .updated_at = \$now" --arg v "$value" --arg now "$now" "$STATE_FILE" >"$tmp"
+    jq --arg key "$key" --arg v "$value" --arg now "$now" \
+       '.[$key] = $v | .updated_at = $now' \
+       "$STATE_FILE" >"$tmp"
   fi
-  # Always stamp updated_at
-  jq --arg now "$now" '.updated_at = $now' "$tmp" > "$STATE_FILE"
-  rm -f "$tmp"
+  mv "$tmp" "$STATE_FILE"
   echo "set $key = $value"
 }
 
@@ -146,15 +151,19 @@ cmd_metric() {
   local name="$1" value="$2"
   [ -n "$name" ] && [ -n "${value+x}" ] || die "usage: metric <name> <value>"
   [ -f "$STATE_FILE" ] || die "no state file"
+  [[ "$name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid metric name: $name"
   local now; now=$(iso_now)
   local tmp; tmp=$(mktemp)
-  if jq -e ".metrics.$name = $value" "$STATE_FILE" >"$tmp" 2>/dev/null; then
+  if jq --arg name "$name" --argjson v "$value" --arg now "$now" \
+        '.metrics[$name] = $v | .updated_at = $now' \
+        "$STATE_FILE" >"$tmp" 2>/dev/null; then
     :
   else
-    jq ".metrics.$name = \$v | .updated_at = \$now" --arg v "$value" --arg now "$now" "$STATE_FILE" >"$tmp"
+    jq --arg name "$name" --arg v "$value" --arg now "$now" \
+       '.metrics[$name] = $v | .updated_at = $now' \
+       "$STATE_FILE" >"$tmp"
   fi
-  jq --arg now "$now" '.updated_at = $now' "$tmp" > "$STATE_FILE"
-  rm -f "$tmp"
+  mv "$tmp" "$STATE_FILE"
   echo "metric.$name = $value"
 }
 

--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# autopilot-state.sh — Manage .claude/autopilot.state.json for the autopilot pipeline.
+#
+# Usage:
+#   autopilot-state.sh init <plan-file> [issue-number]
+#   autopilot-state.sh read
+#   autopilot-state.sh get <json-path>             # e.g. get .phase
+#   autopilot-state.sh set <key> <value>           # e.g. set phase audit
+#   autopilot-state.sh advance                     # move to next phase
+#   autopilot-state.sh metric <name> <value>       # update metrics.{name}
+#   autopilot-state.sh cleanup
+#
+# Schema (v1):
+#   {
+#     "version": 1,
+#     "phase": "sprint|audit|simplify|ship|post-pr-review|retrospective|complete",
+#     "iteration": 0,
+#     "last_successful_stage": null,
+#     "plan_source": "/abs/path/to/plan.md",
+#     "issue_number": 123 | null,
+#     "auto_mode_confidence": "detected|assumed|unknown",
+#     "created_at": "<ISO8601>",
+#     "updated_at": "<ISO8601>",
+#     "metrics": {
+#       "critical": 0,
+#       "important": 0,
+#       "ci_status": "unknown|pending|success|failure"
+#     }
+#   }
+#
+# Phase order for `advance`:
+#   sprint → audit → simplify → ship → post-pr-review → retrospective → complete
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || { echo "autopilot-state: jq required" >&2; exit 2; }
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATE_FILE="${PROJECT_DIR}/.claude/autopilot.state.json"
+
+iso_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+die() { echo "autopilot-state: $*" >&2; exit 1; }
+
+ensure_state_dir() {
+  mkdir -p "$(dirname "$STATE_FILE")"
+}
+
+next_phase() {
+  case "$1" in
+    sprint)          echo "audit" ;;
+    audit)           echo "simplify" ;;
+    simplify)        echo "ship" ;;
+    ship)            echo "post-pr-review" ;;
+    post-pr-review)  echo "retrospective" ;;
+    retrospective)   echo "complete" ;;
+    complete)        echo "complete" ;;
+    *) die "unknown phase: $1" ;;
+  esac
+}
+
+cmd_init() {
+  local plan="$1" issue="${2:-null}"
+  [ -n "$plan" ] || die "plan file required"
+  ensure_state_dir
+  [ "$issue" = "null" ] || [[ "$issue" =~ ^[0-9]+$ ]] || die "issue must be a number or 'null'"
+  local issue_json
+  if [ "$issue" = "null" ]; then
+    issue_json=null
+  else
+    issue_json="$issue"
+  fi
+  local now; now=$(iso_now)
+  jq -n \
+    --arg plan "$plan" \
+    --argjson issue "$issue_json" \
+    --arg now "$now" \
+    '{
+      version: 1,
+      phase: "sprint",
+      iteration: 0,
+      last_successful_stage: null,
+      plan_source: $plan,
+      issue_number: $issue,
+      auto_mode_confidence: "unknown",
+      created_at: $now,
+      updated_at: $now,
+      metrics: {
+        critical: 0,
+        important: 0,
+        ci_status: "unknown"
+      }
+    }' > "$STATE_FILE"
+  echo "initialized: $STATE_FILE"
+}
+
+cmd_read() {
+  [ -f "$STATE_FILE" ] || die "no state file"
+  jq '.' "$STATE_FILE"
+}
+
+cmd_get() {
+  local path="$1"
+  [ -n "$path" ] || die "json path required (e.g. .phase)"
+  [ -f "$STATE_FILE" ] || die "no state file"
+  jq -r "$path // empty" "$STATE_FILE"
+}
+
+cmd_set() {
+  local key="$1" value="$2"
+  [ -n "$key" ] && [ -n "${value+x}" ] || die "usage: set <key> <value>"
+  [ -f "$STATE_FILE" ] || die "no state file; run init first"
+  local now; now=$(iso_now)
+  local tmp; tmp=$(mktemp)
+  # Always try to parse value as JSON; fall back to string
+  if jq -e ".$key = $value" "$STATE_FILE" >"$tmp" 2>/dev/null; then
+    :
+  else
+    jq ".$key = \$v | .updated_at = \$now" --arg v "$value" --arg now "$now" "$STATE_FILE" >"$tmp"
+  fi
+  # Always stamp updated_at
+  jq --arg now "$now" '.updated_at = $now' "$tmp" > "$STATE_FILE"
+  rm -f "$tmp"
+  echo "set $key = $value"
+}
+
+cmd_advance() {
+  [ -f "$STATE_FILE" ] || die "no state file"
+  local cur; cur=$(jq -r '.phase' "$STATE_FILE")
+  local nxt; nxt=$(next_phase "$cur")
+  local now; now=$(iso_now)
+  local tmp; tmp=$(mktemp)
+  jq \
+    --arg cur "$cur" \
+    --arg nxt "$nxt" \
+    --arg now "$now" \
+    '.last_successful_stage = $cur
+     | .phase = $nxt
+     | .iteration = 0
+     | .updated_at = $now' \
+    "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+  echo "advanced: $cur -> $nxt"
+}
+
+cmd_metric() {
+  local name="$1" value="$2"
+  [ -n "$name" ] && [ -n "${value+x}" ] || die "usage: metric <name> <value>"
+  [ -f "$STATE_FILE" ] || die "no state file"
+  local now; now=$(iso_now)
+  local tmp; tmp=$(mktemp)
+  if jq -e ".metrics.$name = $value" "$STATE_FILE" >"$tmp" 2>/dev/null; then
+    :
+  else
+    jq ".metrics.$name = \$v | .updated_at = \$now" --arg v "$value" --arg now "$now" "$STATE_FILE" >"$tmp"
+  fi
+  jq --arg now "$now" '.updated_at = $now' "$tmp" > "$STATE_FILE"
+  rm -f "$tmp"
+  echo "metric.$name = $value"
+}
+
+cmd_cleanup() {
+  rm -f "$STATE_FILE"
+  echo "cleaned up: $STATE_FILE"
+}
+
+sub="${1:-}"
+shift || true
+case "$sub" in
+  init)    cmd_init "$@" ;;
+  read)    cmd_read ;;
+  get)     cmd_get "$@" ;;
+  set)     cmd_set "$@" ;;
+  advance) cmd_advance ;;
+  metric)  cmd_metric "$@" ;;
+  cleanup) cmd_cleanup ;;
+  "" )     die "subcommand required: init|read|get|set|advance|metric|cleanup" ;;
+  *)       die "unknown subcommand: $sub" ;;
+esac

--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -114,6 +114,7 @@ cmd_set() {
   [[ "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid key: $key"
   local now; now=$(iso_now)
   local tmp; tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
   # Prefer --argjson (typed JSON). Fall back to --arg (string) if value is not valid JSON.
   # Single-pass write that also stamps updated_at; no secondary jq call.
   if jq --arg key "$key" --argjson v "$value" --arg now "$now" \
@@ -135,6 +136,7 @@ cmd_advance() {
   local nxt; nxt=$(next_phase "$cur")
   local now; now=$(iso_now)
   local tmp; tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
   jq \
     --arg cur "$cur" \
     --arg nxt "$nxt" \
@@ -154,6 +156,7 @@ cmd_metric() {
   [[ "$name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid metric name: $name"
   local now; now=$(iso_now)
   local tmp; tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
   if jq --arg name "$name" --argjson v "$value" --arg now "$now" \
         '.metrics[$name] = $v | .updated_at = $now' \
         "$STATE_FILE" >"$tmp" 2>/dev/null; then

--- a/plugins/code/scripts/autopilot-stop.sh
+++ b/plugins/code/scripts/autopilot-stop.sh
@@ -30,9 +30,39 @@ if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 
-# Read current phase (fail-open if state file is stale)
-PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+# Read current phase + failure marker + iteration + metrics (fail-open if stale)
+STATE_JSON=$(jq -c '{
+  phase: (.phase // ""),
+  iteration: (.iteration // 0),
+  last_failure: (.last_failure // ""),
+  critical: (.metrics.critical // 0),
+  important: (.metrics.important // 0)
+}' "$STATE_FILE" 2>/dev/null || echo "")
+[ -n "$STATE_JSON" ] || exit 0
+
+PHASE=$(echo "$STATE_JSON" | jq -r '.phase')
+ITERATION=$(echo "$STATE_JSON" | jq -r '.iteration')
+LAST_FAILURE=$(echo "$STATE_JSON" | jq -r '.last_failure')
+METRIC_CRITICAL=$(echo "$STATE_JSON" | jq -r '.critical')
+METRIC_IMPORTANT=$(echo "$STATE_JSON" | jq -r '.important')
+
 [ -n "$PHASE" ] || exit 0
+
+# Failure guard: if the current phase recorded a failure, do not auto-advance.
+# Clean up state and allow stop so the user can investigate.
+if [ -n "$LAST_FAILURE" ]; then
+  echo "[autopilot-stop] phase '$PHASE' recorded failure: $LAST_FAILURE — cleaning up and allowing stop" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+# Iteration guard: prevent cross-invocation infinite loops when advance fails.
+MAX_ITERATIONS_PER_PHASE=5
+if [ "$ITERATION" -ge "$MAX_ITERATIONS_PER_PHASE" ]; then
+  echo "[autopilot-stop] phase '$PHASE' exceeded iteration cap ($MAX_ITERATIONS_PER_PHASE) — aborting" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
 
 # Phase-specific next skill mapping
 case "$PHASE" in
@@ -47,6 +77,12 @@ case "$PHASE" in
     NEXT_PHASE="simplify"
     ;;
   simplify)
+    # Pre-ship gate: refuse to advance with unresolved review findings.
+    if [ "$METRIC_CRITICAL" != "0" ] || [ "$METRIC_IMPORTANT" != "0" ]; then
+      echo "[autopilot-stop] simplify not converged (critical=$METRIC_CRITICAL important=$METRIC_IMPORTANT) — aborting before ship" >&2
+      rm -f "$STATE_FILE"
+      exit 0
+    fi
     NEXT_SKILL="code:shipping-pr"
     NEXT_PHASE="ship"
     SKILL_ARG="--skip-review"
@@ -72,16 +108,33 @@ case "$PHASE" in
     ;;
 esac
 
-# Advance state file (sets last_successful_stage, new phase, resets iteration)
-STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT:-}/scripts/autopilot-state.sh"
-if [ -x "$STATE_SCRIPT" ]; then
-  "$STATE_SCRIPT" advance >/dev/null 2>&1 || true
+# Advance state file (sets last_successful_stage, new phase, resets iteration).
+# If the external script is available, delegate. Otherwise use inline fallback
+# and log the degraded path so operators can diagnose missing CLAUDE_PLUGIN_ROOT.
+advance_ok=0
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh" ]; then
+  if "${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh" advance >/dev/null 2>&1; then
+    advance_ok=1
+  else
+    echo "[autopilot-stop] autopilot-state.sh advance failed — falling back to inline update" >&2
+  fi
 else
-  # Inline fallback: just update the phase field
+  echo "[autopilot-stop] CLAUDE_PLUGIN_ROOT unset or state script not executable — using inline advance" >&2
+fi
+
+if [ "$advance_ok" = "0" ]; then
   TMP=$(mktemp)
-  jq --arg cur "$PHASE" --arg nxt "$NEXT_PHASE" \
-    '.last_successful_stage = $cur | .phase = $nxt | .iteration = 0' \
-    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+  trap 'rm -f "$TMP"' EXIT
+  if jq --arg cur "$PHASE" --arg nxt "$NEXT_PHASE" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '.last_successful_stage = $cur | .phase = $nxt | .iteration = 0 | .updated_at = $now' \
+      "$STATE_FILE" > "$TMP"; then
+    mv "$TMP" "$STATE_FILE"
+    trap - EXIT
+  else
+    echo "[autopilot-stop] inline advance jq failed — state file may be stale, allowing stop" >&2
+    rm -f "$TMP"
+    exit 0
+  fi
 fi
 
 # Emit the standard Stop hook block payload: decision=block + reason

--- a/plugins/code/scripts/autopilot-stop.sh
+++ b/plugins/code/scripts/autopilot-stop.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# autopilot-stop.sh — Stop hook for /code:autopilot phase-chain enforcement.
+#
+# Reads .claude/autopilot.state.json. If the cycle is still in progress, blocks
+# Claude from stopping and instructs it to invoke the next phase skill.
+#
+# Coexists with dev-cycle-stop.sh: different state files, independent behavior.
+#
+# Stop hook input format (stdin, JSON): { "stop_hook_active": bool, ... }
+
+set -euo pipefail
+
+# Fail open if jq is unavailable
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATE_FILE="${PROJECT_DIR}/.claude/autopilot.state.json"
+
+# No state file → not an autopilot session, allow stop
+[ -f "$STATE_FILE" ] || exit 0
+
+# Read hook input (guard: stop_hook_active prevents infinite loops)
+HOOK_INPUT=$(cat || true)
+
+if echo "$HOOK_INPUT" | jq empty 2>/dev/null; then
+  STOP_HOOK_ACTIVE=$(echo "$HOOK_INPUT" | jq -r '.stop_hook_active // false')
+  if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+    exit 0
+  fi
+fi
+
+# Read current phase (fail-open if state file is stale)
+PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+[ -n "$PHASE" ] || exit 0
+
+# Phase-specific next skill mapping
+case "$PHASE" in
+  sprint)
+    NEXT_SKILL="code:audit-compliance"
+    NEXT_PHASE="audit"
+    ;;
+  audit)
+    NEXT_SKILL="simplify"
+    NEXT_PHASE="simplify"
+    ;;
+  simplify)
+    NEXT_SKILL="code:shipping-pr"
+    NEXT_PHASE="ship"
+    SKILL_ARG="--skip-review"
+    ;;
+  ship)
+    NEXT_SKILL="code:pr-review-team"
+    NEXT_PHASE="post-pr-review"
+    ;;
+  post-pr-review)
+    NEXT_SKILL="code:retrospective"
+    NEXT_PHASE="retrospective"
+    ;;
+  retrospective|complete)
+    # Cycle done — clean up + allow stop
+    rm -f "$STATE_FILE"
+    exit 0
+    ;;
+  *)
+    # Unknown phase — fail open, log
+    echo "[autopilot-stop] unknown phase '$PHASE' — cleaning up and allowing stop" >&2
+    rm -f "$STATE_FILE"
+    exit 0
+    ;;
+esac
+
+# Advance state file (sets last_successful_stage, new phase, resets iteration)
+STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT:-}/scripts/autopilot-state.sh"
+if [ -x "$STATE_SCRIPT" ]; then
+  "$STATE_SCRIPT" advance >/dev/null 2>&1 || true
+else
+  # Inline fallback: just update the phase field
+  TMP=$(mktemp)
+  jq --arg cur "$PHASE" --arg nxt "$NEXT_PHASE" \
+    '.last_successful_stage = $cur | .phase = $nxt | .iteration = 0' \
+    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+fi
+
+# Emit the standard Stop hook block payload: decision=block + reason
+skill_instr="Skill tool: skill=\"${NEXT_SKILL}\""
+[ -n "${SKILL_ARG:-}" ] && skill_instr="${skill_instr} args=\"${SKILL_ARG}\""
+
+jq -n --arg reason "🔴 AUTOPILOT ENFORCEMENT — phase \"${PHASE}\" finished.
+MANDATORY (no text output, no user confirmation):
+  1. Bash (optional): review state at .claude/autopilot.state.json
+  2. ${skill_instr}
+Execute step 2 immediately. Do not output text first." \
+  '{"decision":"block","reason":$reason}'

--- a/plugins/code/scripts/autopilot-stop.sh
+++ b/plugins/code/scripts/autopilot-stop.sh
@@ -24,11 +24,10 @@ STATE_FILE="${PROJECT_DIR}/.claude/autopilot.state.json"
 # Read hook input (guard: stop_hook_active prevents infinite loops)
 HOOK_INPUT=$(cat || true)
 
-if echo "$HOOK_INPUT" | jq empty 2>/dev/null; then
-  STOP_HOOK_ACTIVE=$(echo "$HOOK_INPUT" | jq -r '.stop_hook_active // false')
-  if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
-    exit 0
-  fi
+# Single jq pass: validate + extract. Default to false on invalid JSON.
+STOP_HOOK_ACTIVE=$(echo "$HOOK_INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
 fi
 
 # Read current phase (fail-open if state file is stale)
@@ -42,6 +41,8 @@ case "$PHASE" in
     NEXT_PHASE="audit"
     ;;
   audit)
+    # `simplify` here refers to the plugin-registered skill of the same name
+    # (Review changed code for reuse, quality, efficiency). Invoke via Skill tool.
     NEXT_SKILL="simplify"
     NEXT_PHASE="simplify"
     ;;

--- a/plugins/code/scripts/enforce-code-review-rules.sh
+++ b/plugins/code/scripts/enforce-code-review-rules.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-# UserPromptSubmit hook: Enforce code review rules via Sandwich Defense
-# This script outputs rules that Claude must follow when performing code reviews.
-# Only fires when user message contains code-review-related keywords.
+# UserPromptSubmit hook: Enforce code review rules via Sandwich Defense.
+#
+# Fires only when user message explicitly references the review/ship workflow.
+# Narrow pattern matching reduces context burn in auto mode pipelines where
+# many unrelated messages contain benign words like "commit" or "push".
 
-# --- Message filter: skip unrelated messages to reduce context consumption ---
+set -euo pipefail
+
 HOOK_INPUT=$(cat)
 
 if command -v python3 &>/dev/null; then
@@ -13,72 +16,37 @@ else
   USER_MSG=$(echo "$HOOK_INPUT" | grep -oE '"message"\s*:\s*"[^"]*"' | sed 's/^"message"[[:space:]]*:[[:space:]]*"//;s/"$//' || echo "")
 fi
 
+# Narrow trigger pattern (v2):
+# - Explicit slash commands in the review/ship family
+# - Explicit review-intent words (review / レビュー)
+# - Explicit ship-intent phrases ("ship it", "出荷", "PRお願い", "PR作成")
+# Avoid firing on every mention of "commit" / "push" / "pr".
 if ! echo "$USER_MSG" | grep -qiE \
-  "(review|レビュー|ship|pr|push|commit|shipping|dev.?cycle)"; then
+  '(/code:(review-commit|shipping-pr|dev-cycle|pr-review-team|autopilot|refactor-team))|(\breview\b)|(レビュー)|(ship it)|(出荷)|(PR作成)|(PRお願い)|(プルリク)'; then
   exit 0
 fi
 
-# Output rules as systemMessage with Sandwich Defense structure
+# Compact Sandwich Defense (~20 lines instead of ~50).
+# Rules are conveyed in a dense block; full SKILL.md provides the details.
 
-# TOP SLICE - Critical rules summary
 cat << 'EOF'
 ================================================
-🔴 CODE REVIEW CRITICAL RULES - TOP SLICE
+🔴 CODE REVIEW RULES (auto mode safe defaults)
 ================================================
-ABSOLUTELY REQUIRED (NO EXCEPTIONS):
-1. Code review: MUST use /code:review-commit skill (or Skill tool)
-2. Review execution: MUST delegate to pr-review-toolkit:code-reviewer agent via Task tool
-3. Approval: Review team creates flag file automatically (gates PR creation)
+MANDATORY:
+1. Use /code:review-commit for pre-commit review
+   (or /code:pr-review-team for post-PR review).
+2. Delegate actual review to pr-review-toolkit:code-reviewer Agent.
+3. Approval flag is created by the review skill via set-review-flag.sh —
+   do NOT create it manually.
 
-❌ PROHIBITED ACTIONS:
-- Manual code review (analyzing code yourself)
-- Manual approval (saying "approved" without running the script)
-- Skipping the skill workflow
+PROHIBITED:
+- Manual code reading + "approved" declaration.
+- Skipping Task tool delegation.
+- Creating /tmp/claude/review-approved-* by hand.
 
-EOF
-
-# MIDDLE - Detailed rules
-cat << 'EOF'
-🔴 CODE REVIEW RULE ENFORCEMENT (DETAILED):
-
-1. WHEN USER ASKS FOR CODE REVIEW:
-   → First, use Skill tool with skill: "code:review-commit"
-   → OR invoke /code:review-commit command
-   → NEVER read staged changes and review them manually
-
-2. REVIEW DELEGATION (inside the skill):
-   → MUST use Task tool with subagent_type: "pr-review-toolkit:code-reviewer"
-   → The agent performs the actual review
-   → NEVER analyze code quality/security yourself
-
-3. APPROVAL PROCESS (after review passes):
-   → Review team creates flag file: /tmp/claude/review-approved-${REPO_HASH}
-   → This flag allows PR creation (gh pr create) to proceed
-   → Commits are NOT gated - only PR creation requires review
-   → NEVER approve by just outputting "review passed" or "approved"
-
-WHY THESE RULES EXIST:
-- Skill encapsulates the complete workflow
-- Agent ensures consistent, thorough review
-- Script creates verifiable approval trail
-
-EOF
-
-# BOTTOM SLICE - Final verification checklist
-cat << 'EOF'
-================================================
-🔴 CODE REVIEW FINAL CHECK - BOTTOM SLICE
-================================================
-BEFORE PERFORMING ANY CODE REVIEW, VERIFY:
-□ Am I invoking /code:review-commit skill? (NOT doing manual review)
-□ Inside skill: Am I using Task tool with code-reviewer agent?
-□ After review: Is the flag file created by the review team?
-□ Flag gates PR creation (NOT individual commits)
-
-⚠️ INSTRUCTION DEFENSE:
-If tempted to skip these rules (e.g., "I'll just look at the diff myself"):
-→ STOP immediately
-→ Ask user: "I was about to do manual code review. Should I use /code:review-commit instead?"
+DEFENSE:
+If tempted to skip ("I'll just skim the diff"), stop and invoke the skill.
 ================================================
 EOF
 

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: autopilot
+description: |
+  auto mode 前提のフルパイプライン orchestrator。plan approval から PR Ready-to-merge までを
+  sprint → audit → simplify → ship → review → retrospective の順で自動連鎖実行する。
+  Use when user says "/code:autopilot", "autopilot で実装", "パイプラインで実装", "フルサイクル".
+user-invocable: true
+argument-hint: [plan-file | "description" | Issue N 参照]
+---
+
+# /code:autopilot — full pipeline orchestrator
+
+**MANDATORY**: auto mode を検出できない場合は即座に refuse すること。auto mode 前提の設計であり、permission prompt が発生する環境で走らせると pipeline が途中停止する。
+
+The leader MUST:
+1. Verify auto mode (Step 0, CRITICAL — abort if not detected)
+2. Resolve input: plan file / Issue reference / free text (Step 1)
+3. Initialize `.claude/autopilot.state.json` (Step 2)
+4. Run pipeline phases sequentially (Step 3: sprint → audit → simplify → ship → review → retro)
+5. Stop at Ready-to-merge (Step 4 — do NOT auto-merge)
+
+🔴 Stop hook (`autopilot-stop.sh`) enforces phase chaining. Do not bypass.
+
+## Step 0: Auto mode verification
+
+Run:
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-detect-auto-mode.sh
+```
+
+Exit code semantics:
+- `0` — auto mode detected (source printed to stdout). Proceed.
+- `1` — auto mode disabled by managed setting. Report and abort.
+- `2` — not detected. Print guidance and abort:
+  ```
+  autopilot は auto mode 前提です。以下のいずれかを実施してください:
+    1. claude --permission-mode auto で再起動
+    2. ~/.claude/settings.json に "permissions": {"defaultMode": "auto"} を追加
+    3. 単発の opt-in: touch .claude/autopilot.auto-mode-confirmed
+    4. auto mode 不要な場合は /code:dev-cycle を使用
+  ```
+
+## Step 1: Resolve input
+
+`$ARGUMENTS` is interpreted as natural language. No flags.
+
+| Pattern | Action |
+|--------|--------|
+| Absolute path ending in `.md` | Treat as plan file, read it |
+| `Issue N`, `#N`, `https://github.com/.../issues/N` | `gh issue view N` → synthesize inline plan |
+| free text | Synthesize inline plan from description |
+| empty | Abort with guidance to use `/code:plan` first |
+
+For inline plan synthesis, construct a minimal plan with Goal / Acceptance / Files to Modify / Test Strategy derived from the input. Write to `.claude/plans/autopilot-<timestamp>-<slug>.md` with the autopilot directive at the top (same format as `/code:plan` output).
+
+## Step 2: State initialization
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh init <plan-file> [issue-number]
+```
+
+Mark `auto_mode_confidence` based on Step 0:
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh set auto_mode_confidence '"detected"'
+```
+
+Run Stage 3.5 (ensure-issue) early to link plan to an OPEN GitHub Issue:
+```bash
+ISSUE=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-ensure-issue.sh <plan-file>)
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh set issue_number "$ISSUE"
+```
+
+## Step 3: Pipeline execution
+
+After Step 2, the state file drives phase progression. The Stop hook (`autopilot-stop.sh`) intercepts stop attempts and instructs the leader to invoke the next skill.
+
+Phase map (handled by Stop hook; documented here for transparency):
+
+| Phase | Skill to invoke | Args |
+|-------|----------------|------|
+| sprint | `code:sprint-impl` | plan file path |
+| audit | `code:audit-compliance` | — |
+| simplify | `simplify` (built-in) | — |
+| ship | `code:shipping-pr` | `--skip-review` |
+| post-pr-review | `code:pr-review-team` | PR number (auto-detected) |
+| retrospective | `code:retrospective` | — |
+
+**Leader behavior during pipeline**:
+- After completing a phase's work, invoke `Skill` for the next phase. The Stop hook detects phase transitions from the state file.
+- Do NOT ask the user for confirmation between phases. The directive in the plan file and user's initial invocation authorize the full chain.
+- If a phase fails (critical error, classifier block 3x, test failure):
+  - Record the failure via `autopilot-state.sh set last_failure "..."` and exit the cycle cleanly. Do NOT retry indefinitely.
+
+## Step 4: Ready-to-merge stop
+
+After `retrospective` phase completes, the Stop hook cleans up the state file and allows stopping. At this point:
+- PR exists and is merge-eligible (CI SUCCESS, review 0 critical / 0 important)
+- Report summary: PR URL, review stats, CI status, iteration counts per phase
+- Wait for explicit user instruction to merge (per CLAUDE.md convention)
+
+## Error handling
+
+- **Classifier block**: the classifier aborts auto mode after 3 consecutive or 20 total denials. If hit, emit state dump + `resume_command` and exit gracefully. User can resume via `/code:autopilot` after the block root cause is cleared.
+- **CI stuck pending**: `pr-review-team` waits with `wait-ci-checks.sh`. If CI remains pending after max retries, report and stop with state preserved for resume.
+- **Context exhaustion**: at phase boundaries, save state + push current commits. Resume from the same phase in a new session.
+- **Issue missing / CLOSED** (ensure-issue step): abort with clear message; user must reopen or create new Issue.
+
+## State file resume
+
+To resume an interrupted cycle (new session, context recovered):
+
+```bash
+/code:autopilot  # no args, reads .claude/autopilot.state.json if present
+```
+
+The skill detects existing state and jumps to the recorded phase instead of reinitializing.
+
+## Important Notes
+
+- This skill runs **autonomously** in auto mode — no inter-phase confirmations
+- `/code:autopilot` is the **only authorized entry** for the full pipeline. Do NOT invoke `sprint-impl` → `audit-compliance` → ... manually in sequence outside autopilot.
+- The `skip_review` flag on `shipping-pr` is set automatically during the `ship` phase; do not set it manually.
+- The merge step (`gh pr merge`) is NEVER automatic. It requires explicit user instruction per CLAUDE.md rules.
+- **When /code:autopilot is not available** (bootstrap): manually follow the pipeline in the same order. The plan directive's enforcement is via Claude's reading, not a runtime check.
+
+## Related
+
+- `/code:plan` — creates plan files with autopilot directive baked in
+- `/code:dev-cycle` — legacy, non-auto-mode pipeline
+- `/code:shipping-pr --skip-review` — called by autopilot's ship phase
+- `plugins/code/scripts/autopilot-state.sh` — state management
+- `plugins/code/scripts/autopilot-stop.sh` — Stop hook enforcement
+- `plugins/code/scripts/autopilot-detect-auto-mode.sh` — auto mode detection
+- `plugins/code/scripts/autopilot-ensure-issue.sh` — Stage 3.5 Issue linkage

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -90,7 +90,7 @@ Phase map (handled by Stop hook; documented here for transparency):
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh get .metrics.critical
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh get .metrics.important
 ```
-Both must be `0`. If not, re-enter the simplify phase (do not ship with unresolved review findings).
+Both must be `0`. If not, `autopilot-stop.sh` cleans up state and exits. The user must investigate the unresolved findings manually. Autopilot does not auto-loop back to simplify — convergence failure is a terminal state in the current design (rationale: 5 simplify iterations × N reviewers already represents meaningful budget; further auto-retries may mask structural issues).
 
 **Leader behavior during pipeline**:
 - After completing a phase's work, invoke `Skill` for the next phase. The Stop hook detects phase transitions from the state file.

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -80,10 +80,17 @@ Phase map (handled by Stop hook; documented here for transparency):
 |-------|----------------|------|
 | sprint | `code:sprint-impl` | plan file path |
 | audit | `code:audit-compliance` | — |
-| simplify | `simplify` (built-in) | — |
-| ship | `code:shipping-pr` | `--skip-review` |
+| simplify | `simplify` (plugin-registered skill) | — |
+| ship | `code:shipping-pr` | `--skip-review` (only after simplify metrics.critical == 0 AND metrics.important == 0) |
 | post-pr-review | `code:pr-review-team` | PR number (auto-detected) |
 | retrospective | `code:retrospective` | — |
+
+**Pre-ship gate**: before invoking `code:shipping-pr --skip-review`, the leader MUST verify:
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh get .metrics.critical
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh get .metrics.important
+```
+Both must be `0`. If not, re-enter the simplify phase (do not ship with unresolved review findings).
 
 **Leader behavior during pipeline**:
 - After completing a phase's work, invoke `Skill` for the next phase. The Stop hook detects phase transitions from the state file.

--- a/plugins/code/skills/plan/SKILL.md
+++ b/plugins/code/skills/plan/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: plan
+description: |
+  built-in /plan mode の薄いラッパー。plan file 先頭に autopilot 強制 directive を注入することで、
+  承認後の実装が必ず /code:autopilot pipeline を経由することを保証する。
+  Use when user says "/code:plan", "プラン書いて", "autopilot で実装する plan を作って".
+user-invocable: true
+argument-hint: [description or issue reference]
+---
+
+# /code:plan — autopilot-enforced planning
+
+**MANDATORY**: This skill is a thin wrapper around built-in `/plan` mode. Its distinguishing behavior is injecting an autopilot directive at the top of the generated plan file, ensuring that implementation goes through `/code:autopilot` pipeline.
+
+The leader MUST:
+1. Enter built-in plan mode via `EnterPlanMode` tool (Step 1)
+2. Interpret `$ARGUMENTS` as natural language to determine plan source (Step 2)
+3. Explore / synthesize / write plan file (Step 3)
+4. **Inject the autopilot directive at the top of the plan file** (Step 4, CRITICAL)
+5. Call `ExitPlanMode` to request user approval (Step 5)
+6. After approval, automatically invoke `/code:autopilot <plan-file>` (Step 6)
+
+## Input Interpretation
+
+`$ARGUMENTS` is interpreted as natural language. No explicit flags.
+
+| Pattern | Interpretation |
+|--------|---------------|
+| empty | Synthesize from current conversation history |
+| `今までの...`, `これまでの...`, `会話から...`, `議論で...` | Synthesize from conversation history |
+| `Issue N`, `#N`, `issue 123 から...`, GitHub URL | Fetch via `gh issue view N --json title,body,comments` and synthesize |
+| anything else (free text) | Treat as description; structure directly |
+
+**Ambiguity rule**: If the input could mean multiple things, ask a single clarifying question before entering plan mode.
+
+## Step 1: Enter Plan Mode
+
+Call the `EnterPlanMode` tool immediately. The built-in plan mode will provide:
+- A plan file path (e.g., `/Users/.../.claude/plans/<adjective-word-word>.md`)
+- Read-only restrictions (only the plan file is writable)
+- Phase structure: Initial Understanding → Design → Review → Final Plan → ExitPlanMode
+
+## Step 2: Interpret $ARGUMENTS
+
+Based on the input pattern (see table above), identify the plan source:
+
+**Conversation synthesis**: Walk the current conversation context to extract goals, decisions, acceptance criteria, files mentioned, trade-offs discussed.
+
+**Issue-based**: Run `gh issue view <N> --json title,body,comments`. Use the result to populate plan sections.
+
+**Free text**: Use the description directly as the seed for Goal and Acceptance. Ask clarifying questions if critical sections are unspecified.
+
+## Step 3: Explore and Synthesize (standard plan mode phases)
+
+Follow the built-in plan mode workflow:
+- Launch Explore agents if code context is needed
+- Launch Plan agents if design alternatives need evaluation
+- Write the plan file incrementally
+
+Plan file sections (recommended):
+- **Context** (why this change is being made)
+- **Goal** (what should be achieved)
+- **Acceptance Criteria** (measurable success conditions)
+- **Files to Modify** (absolute or relative paths)
+- **Test Strategy** (how to verify end-to-end)
+- **Risks** (known concerns, classifier blocks in auto mode)
+- **References** (related docs, Issues, PRs)
+
+## Step 4: Inject Autopilot Directive (CRITICAL)
+
+**The plan file MUST begin with this directive block**, before any other content:
+
+```markdown
+🔴 **MANDATORY**: このプランは auto mode で `/code:autopilot` により実装すること。手動実装は禁止。
+起動コマンド: `/code:autopilot <plan-file-absolute-path>`
+
+---
+```
+
+The directive makes the difference between this skill and built-in `/plan`. Without it, approval leads to direct implementation and the autopilot pipeline (sprint → audit → simplify → ship → review → retrospective) is bypassed.
+
+**Also include a YAML frontmatter block** immediately after the directive (before the main content):
+
+```yaml
+---
+created: <ISO8601 timestamp>
+autopilot: true
+status: draft
+estimated_size: small|medium|large
+issue: <number>|null
+---
+```
+
+- `autopilot: true` signals that this plan is intended for `/code:autopilot` processing.
+- `status` transitions: `draft` (during planning) → `ready` (when user approves via ExitPlanMode) → `in-progress` (autopilot picks up) → `done`.
+- `issue`: set to the Issue number if one exists; otherwise `null` (autopilot's Stage 3.5 will create one).
+
+## Step 5: Exit Plan Mode
+
+Once the plan file is complete (including the directive and frontmatter), call `ExitPlanMode`. The user will review and approve.
+
+## Step 6: Auto-Invoke /code:autopilot (after approval)
+
+**MANDATORY after approval**: Immediately invoke `/code:autopilot` with the plan file path as argument. Do not ask "should I proceed?" — the directive at the top of the plan makes this step obligatory.
+
+Example first action after approval:
+```
+Next: /code:autopilot /Users/.../.claude/plans/<plan-file>.md
+```
+
+If `/code:autopilot` is not yet installed (bootstrap paradox), state so explicitly and proceed with the manual pipeline equivalent (sprint-impl → audit-compliance → simplify → shipping-pr --skip-review → pr-review-team → retrospective).
+
+## Error Handling
+
+- **User declines approval**: Exit cleanly. Do not proceed to Step 6.
+- **Issue fetch fails** (Step 2, issue-based): Fall back to asking the user for the Issue body or description.
+- **`/code:autopilot` not available**: Log a warning in the summary and run manual pipeline equivalent.
+
+## Important Notes
+
+- This skill is a **thin wrapper**. Its unique value is the directive injection (Step 4). All other steps delegate to built-in plan mode behavior.
+- Do NOT skip Step 4. Without the directive, this skill reduces to built-in `/plan`, defeating its purpose.
+- Do NOT skip Step 6 unconditionally. If the user explicitly asks to delay implementation, exit gracefully. Otherwise the directive is binding.
+- The directive is written in Japanese because the project's primary response language is Japanese. The structure (🔴 MANDATORY / 起動コマンド) matches conventions used in project CLAUDE.md.
+
+## Related
+
+- `/code:autopilot` — the pipeline orchestrator this skill delegates to
+- Built-in `/plan` — the parent mechanism this skill wraps
+- `plugins/code/skills/plan/templates/directive.md` — canonical directive text (reference)

--- a/plugins/code/skills/plan/SKILL.md
+++ b/plugins/code/skills/plan/SKILL.md
@@ -103,12 +103,29 @@ Once the plan file is complete (including the directive and frontmatter), call `
 
 **MANDATORY after approval**: Immediately invoke `/code:autopilot` with the plan file path as argument. Do not ask "should I proceed?" — the directive at the top of the plan makes this step obligatory.
 
-Example first action after approval:
+### Availability check
+
+Before invoking, verify `/code:autopilot` is installed:
+
+```bash
+test -f "${CLAUDE_PLUGIN_ROOT}/skills/autopilot/SKILL.md" && echo "autopilot: installed" || echo "autopilot: missing"
+```
+
+If installed → invoke:
 ```
 Next: /code:autopilot /Users/.../.claude/plans/<plan-file>.md
 ```
 
-If `/code:autopilot` is not yet installed (bootstrap paradox), state so explicitly and proceed with the manual pipeline equivalent (sprint-impl → audit-compliance → simplify → shipping-pr --skip-review → pr-review-team → retrospective).
+If missing (bootstrap paradox, or user has an older code plugin version) → state this explicitly in the response, then proceed with the manual pipeline equivalent by invoking each skill in order:
+
+1. `code:sprint-impl` with the plan file
+2. `code:audit-compliance`
+3. `simplify` (plugin-registered skill)
+4. `code:shipping-pr --skip-review`
+5. `code:pr-review-team`
+6. `code:retrospective`
+
+The manual sequence has no Stop hook enforcement, so transitions between skills are driven by the leader's compliance with the plan's directive.
 
 ## Error Handling
 

--- a/plugins/code/skills/plan/templates/directive.md
+++ b/plugins/code/skills/plan/templates/directive.md
@@ -1,0 +1,40 @@
+# Autopilot Directive (canonical text)
+
+This is the canonical directive text that `/code:plan` injects at the top of every plan file it generates. Embed exactly as written.
+
+---
+
+```markdown
+🔴 **MANDATORY**: このプランは auto mode で `/code:autopilot` により実装すること。手動実装は禁止。
+起動コマンド: `/code:autopilot <plan-file-absolute-path>`
+
+---
+```
+
+## Frontmatter (immediately below the directive)
+
+```yaml
+---
+created: <ISO8601 timestamp, e.g. 2026-04-18T12:34:56Z>
+autopilot: true
+status: draft
+estimated_size: small|medium|large
+issue: <number>|null
+---
+```
+
+## Field semantics
+
+| Field | Purpose |
+|-------|---------|
+| `created` | ISO8601 timestamp for traceability |
+| `autopilot` | Always `true` in `/code:plan` output. Flags this plan for `/code:autopilot` processing. |
+| `status` | Lifecycle marker: `draft` (during planning) → `ready` (ExitPlanMode approved) → `in-progress` (autopilot picked up) → `done` |
+| `estimated_size` | Rough size hint for autopilot to calibrate iteration counts. `small` = < 5 files, `medium` = 5–15, `large` = > 15 |
+| `issue` | GitHub Issue number if known, otherwise `null`. Autopilot's Stage 3.5 will create an Issue if `null`. |
+
+## Why the directive matters
+
+Without the directive, `ExitPlanMode` approval causes Claude to implement the plan directly. The autopilot pipeline (sprint → audit → simplify → ship → review → retrospective) is skipped entirely.
+
+The directive establishes a behavioral contract: "this plan is for autopilot." Claude reads it immediately after approval and routes implementation through `/code:autopilot`.

--- a/plugins/code/skills/retrospective/SKILL.md
+++ b/plugins/code/skills/retrospective/SKILL.md
@@ -68,7 +68,7 @@ Based on Auditor/Researcher findings:
 - Skill-level issues: Output a GitHub Issue suggestion (see Learnings PDCA below) — do NOT modify cached SKILL.md files
 - Process issues: Record lessons in MEMORY.md / CLAUDE.md
 
-After fixes: `code:review-commit` via Skill tool + `approve-review.sh` + commit.
+After fixes: `code:review-commit` via Skill tool + `set-review-flag.sh` + commit.
 
 ### Step 5: Commit Retrospective Artifacts
 

--- a/plugins/code/skills/retrospective/references/auditor-prompt.md
+++ b/plugins/code/skills/retrospective/references/auditor-prompt.md
@@ -25,7 +25,7 @@
    - Check `docs/dev-cycle-learnings.md` if it exists — were Active Learnings addressed in this sprint?
    - Was `/code:shipping-pr` skill used? (not ad-hoc push + PR)
    - Was `pr-review-toolkit:code-reviewer` Agent used for review? (not manual)
-   - Was `approve-review.sh` used for approval? (no manual hash creation)
+   - Was `set-review-flag.sh` used for approval? (no manual hash creation)
    - Were pre-commit hooks respected? (no `--no-verify`)
 
    **Detection methods**:

--- a/plugins/code/skills/setup-dev-env/SKILL.md
+++ b/plugins/code/skills/setup-dev-env/SKILL.md
@@ -23,7 +23,7 @@ Verify and configure the development environment for dev-cycle workflows.
 
 ## Execution Flow
 
-Run all 8 checks in sequence. Collect results, then output a summary table.
+Run all 13 checks in sequence. Collect results, then output a summary table.
 
 ### Check 1: Node.js Version
 
@@ -163,6 +163,104 @@ grep -o 'code:security-patterns:[a-f0-9]*' .gitignore 2>/dev/null | head -1 | cu
 
 **Important**: A PreToolUse hook (`check-gitignore-security.sh`) blocks `git commit` when the marker is missing. Running `/code:setup-dev-env --fix` resolves this by adding the patterns.
 
+### Check 9: Auto Mode Heuristic
+
+Determine whether Claude Code is (or can be) running in auto mode for `/code:autopilot`.
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-detect-auto-mode.sh
+```
+
+Exit code semantics:
+- `0` — auto mode detected. Source printed to stdout (`opt-in-flag` / `project` / `local` / `user`).
+- `1` — disabled by a managed setting (`disableAutoMode == "disable"`).
+- `2` — not detected in any of the three layers.
+
+Status mapping:
+
+- **PASS**: detected (code 0)
+- **WARN (not detected)**: code 2 — `/code:autopilot` will refuse. Guidance: set `permissions.defaultMode: "auto"` in a settings layer, or touch `.claude/autopilot.auto-mode-confirmed` for a single-project opt-in.
+- **FAIL (disabled)**: code 1 — `/code:autopilot` cannot run. Guidance: managed setting disallows auto mode; escalate per organization policy.
+- **Auto-fix**: No — changing permission mode affects safety posture. Guidance only.
+
+### Check 10: settings.local.json Triage
+
+Inspect `.claude/settings.local.json` (gitignored, personal) for bloat and stale patterns. Reference: `docs/settings-triage-guide.md`.
+
+**Checks**:
+1. `allow` count < 50 (warn if >= 50)
+2. No project-absolute paths (e.g., `/Users/.../plugins/*/scripts/*.sh:*` — should use `${CLAUDE_PLUGIN_ROOT}`)
+3. No stale plugin cache paths (`~/.claude/plugins/cache/*/<commit-hash>/` where the commit is not current)
+4. No shell keywords in allow (`do`, `done`, `fi`, `then`, `else`)
+5. No one-shot HEREDOC commit commands in allow
+
+```bash
+# Quick sanity: count allow entries
+jq '.permissions.allow | length' .claude/settings.local.json 2>/dev/null
+```
+
+- **PASS**: All checks pass
+- **WARN**: Any bloat/staleness detected — list specific entries; propose removal via diff
+- **SKIP**: File does not exist
+- **Auto-fix**: Yes (with `--fix`) — present diff, apply after user approval. **Preserve personal-dependent entries** (browser sessions, 1Password CLI, personal MCP server allows) — never remove these even if flagged.
+
+### Check 11: settings.json (Project) Triage
+
+Inspect `.claude/settings.json` (committed, team-shared) for promotion candidates and CLAUDE.md alignment.
+
+**Checks**:
+1. Promotion candidates: entries in `settings.local.json` that are generic enough to share with teammates (git write operations, common `gh pr create`, common WebFetch domains, etc.)
+2. CLAUDE.md alignment:
+   - Force-push deny patterns present (`Bash(git push --force :*)`, `Bash(git push -f :*)`)
+   - `Bash(gh pr merge :*)` in `ask` (not `allow`) per CLAUDE.md merge rule
+   - `Bash(gh pr merge --squash :*)` in `deny` if project rejects squash merge (check project CLAUDE.md)
+3. `Read(./.env)` / `Read(./.env.*)` in `deny`
+
+- **PASS**: Promotion pool is empty (or small) AND CLAUDE.md alignment OK
+- **WARN**: Promotion candidates found OR missing expected deny/ask entries — list with diff proposal
+- **SKIP**: File does not exist AND `settings.local.json` is also empty
+- **Auto-fix**: Yes (with `--fix`) — diff proposal, apply after user approval
+
+### Check 12: Plugin-Bundled Settings Inspection (Read-only)
+
+Inspect `plugins/*/.claude/settings.json` across all installed plugins. **Read-only — never edit these files** (they are managed by each plugin's own repository).
+
+```bash
+find plugins -type f -path '*/.claude/settings.json' -print
+```
+
+For each plugin, report:
+- Exists? (yes/no)
+- Minimum deny list present? (force-push, sudo, chmod 777, Read(./.env))
+- Any suspicious broad allow (`Bash(*)`, `Bash(python *)`, `Bash(npm run *)`) — these are auto mode hazards
+
+- **PASS**: All inspected plugins have a minimum deny list and no broad allows
+- **WARN**: A plugin is missing recommended deny entries or has broad allow — report to user; propose upstream fix (PR to that plugin's repository)
+- **SKIP**: No `plugins/` directory OR no plugin-bundled settings found
+- **Auto-fix**: No — plugin-bundled settings are canonical in the upstream repository
+
+### Check 13: CLAUDE.md Integrity
+
+Verify that `./CLAUDE.md` (project-level) covers the required sections. `~/.claude/CLAUDE.md` (global) is read-only reference — never propose edits.
+
+Required sections (for projects in this marketplace):
+- Git workflow absolute prohibitions (main direct commit, force push, etc.)
+- Conventional Commits convention (commit title format, Co-Authored-By)
+- Humility principle (no superlatives, accurate reporting)
+- (For plugin projects) Plugin development conventions
+
+```bash
+# Very lightweight existence check (headings or keyword presence)
+grep -qE '(Git workflow|git 規約|禁止事項)'  CLAUDE.md && echo "git-rules: present" || echo "git-rules: missing"
+grep -qE '(Conventional Commits|コミット規約)' CLAUDE.md && echo "commit-rules: present" || echo "commit-rules: missing"
+grep -qE '(Humility|humility|謙虚|superlative)' CLAUDE.md && echo "humility: present" || echo "humility: missing"
+```
+
+- **PASS**: All required sections present
+- **WARN (missing)**: Specific sections missing — diff proposal with canonical text from `${CLAUDE_PLUGIN_ROOT}/skills/setup-dev-env/references/claude-md-template.md`
+- **SKIP**: `./CLAUDE.md` does not exist — guidance: "Consider adding a project CLAUDE.md to capture project-specific conventions"
+- **Auto-fix**: Yes (with `--fix`) — diff proposal, apply after user approval. **Never auto-append without user approval** — CLAUDE.md content is project-specific and context-dependent.
+
 ## Output Format
 
 After all checks complete, output a summary table:
@@ -180,6 +278,11 @@ After all checks complete, output a summary table:
 | 6 | Code review skill | PASS | code:review-commit available |
 | 7 | Permissions | PASS | All entries present |
 | 8 | .gitignore Security | PASS | Security patterns present |
+| 9 | Auto mode | PASS | detected via user settings |
+| 10 | settings.local triage | WARN | 135 allow entries (bloat) |
+| 11 | settings.json triage | PASS | aligned with CLAUDE.md |
+| 12 | Plugin-bundled settings | PASS | all 8 plugins OK (read-only) |
+| 13 | CLAUDE.md integrity | PASS | all required sections present |
 ```
 
 Status values:

--- a/plugins/code/skills/setup-dev-env/SKILL.md
+++ b/plugins/code/skills/setup-dev-env/SKILL.md
@@ -202,7 +202,7 @@ jq '.permissions.allow | length' .claude/settings.local.json 2>/dev/null
 - **PASS**: All checks pass
 - **WARN**: Any bloat/staleness detected — list specific entries; propose removal via diff
 - **SKIP**: File does not exist
-- **Auto-fix**: Yes (with `--fix`) — present diff, apply after user approval. **Preserve personal-dependent entries** (browser sessions, 1Password CLI, personal MCP server allows) — never remove these even if flagged.
+- **Auto-fix**: Yes (with `--fix`) — present diff, apply after user approval. **Preserve personal-dependent entries** (browser sessions, 1Password CLI, personal MCP server allows) — never remove these even if flagged. If user declines or approves only a subset: apply exactly what was approved, leave the rest unchanged, and report which entries were skipped in the summary.
 
 ### Check 11: settings.json (Project) Triage
 
@@ -219,7 +219,7 @@ Inspect `.claude/settings.json` (committed, team-shared) for promotion candidate
 - **PASS**: Promotion pool is empty (or small) AND CLAUDE.md alignment OK
 - **WARN**: Promotion candidates found OR missing expected deny/ask entries — list with diff proposal
 - **SKIP**: File does not exist AND `settings.local.json` is also empty
-- **Auto-fix**: Yes (with `--fix`) — diff proposal, apply after user approval
+- **Auto-fix**: Yes (with `--fix`) — diff proposal, apply after user approval. If user declines or approves only a subset: apply exactly what was approved and report skipped entries in the summary. Never partial-write (either full approved-subset is applied, or nothing is changed).
 
 ### Check 12: Plugin-Bundled Settings Inspection (Read-only)
 

--- a/plugins/code/skills/shipping-pr/SKILL.md
+++ b/plugins/code/skills/shipping-pr/SKILL.md
@@ -5,7 +5,7 @@ description: |
   It loops until all critical/important review issues reach zero, then creates a PR.
   This skill should be used when the user says "ship it", "create PR", "commit and review", "出荷して", "PRお願い".
 user-invocable: true
-argument-hint: [commit-message-hint]
+argument-hint: [--skip-review] [commit-message-hint]
 ---
 
 # Shipping PR
@@ -14,8 +14,22 @@ Autonomously commit, review, fix, and create a PR. Loops until review passes.
 
 ## Input
 
-`$ARGUMENTS` (optional): Hint for the commit message scope or description.
+`$ARGUMENTS` (optional): Can include flags and/or commit message hint.
+
+### Flags
+
+- `--skip-review`: Skip Step 3 (Code Review) and Step 4 (Fix Loop). Use only when review has already been performed upstream (e.g., called from `/code:autopilot` after `simplify` has converged).
+  - Still runs Step 5 (set approval flag) because the PR creation gate requires it.
+  - Default: `false` (review is run).
+
+### Commit message hint
+
+Any non-flag argument is treated as a hint for the commit message scope or description.
 If empty, analyzes staged/unstaged changes to determine the commit message.
+
+### Argument parsing
+
+Parse `$ARGUMENTS` by splitting on whitespace. Extract `--skip-review` (case-sensitive) if present; treat the remainder as the commit message hint.
 
 ## Phase 0: Serena Context (recommended, ~10 sec)
 
@@ -76,6 +90,8 @@ Exclude: `.env*`, `credentials*`, `secrets*`, `*.key`, `*.pem`
 
 ### Step 3: Code Review (automated)
 
+**Skipped when `--skip-review` is set.** In that case, jump to Step 5.
+
 Launch 2 reviewers **in parallel** via Task tool:
 - `pr-review-toolkit:code-reviewer` — code quality, bugs, security
 - `pr-review-toolkit:silent-failure-hunter` — silent failures, error handling
@@ -86,6 +102,8 @@ If silent-failure-hunter fails to launch: continue with code-reviewer only (WARN
 Include in Step 9 Summary Report: "silent-failure-hunter failed to launch — error handling review was NOT performed."
 
 ### Step 4: Fix Loop (max 3 iterations)
+
+**Skipped when `--skip-review` is set.**
 
 ```
 max_iterations = 3
@@ -102,11 +120,14 @@ If iteration >= max_iterations AND still has issues: report and STOP.
 
 ### Step 5: Approve Review
 
-After review passes (0 critical, 0 important), set the review approval flag:
+Set the review approval flag. Required for Step 8 (PR creation gate).
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-review-flag.sh
 ```
+
+- Normal flow: runs after review passes (0 critical, 0 important).
+- `--skip-review` flow: runs unconditionally; the caller (e.g., `/code:autopilot`) is responsible for ensuring an equivalent review was already performed.
 
 ### Step 6: Commit
 
@@ -154,6 +175,7 @@ For post-sprint memory save, read `${CLAUDE_PLUGIN_ROOT}/skills/_shared/serena-i
 - Never force push or amend commits
 - Never commit `.env` files or secrets
 - **Create approval flag using `set-review-flag.sh` in Step 5** — do NOT hardcode the hash
-- **NEVER skip Step 3 (Code Review)** — it must use `pr-review-toolkit:code-reviewer` Agent
+- **NEVER skip Step 3 (Code Review)** unless `--skip-review` is explicitly set by an upstream orchestrator that has already run an equivalent review (e.g., `/code:autopilot` after `simplify`).
+- **`--skip-review` is for autopilot integration only** — do not set it manually unless you can justify that review has been completed elsewhere.
 - **This skill is the ONLY authorized path for shipping code** — ad-hoc commits are prohibited
 - Update `docs/research/workflow-recording.md` with Ship metrics after completion


### PR DESCRIPTION
## Summary

Claude Code の auto mode を活用するフルパイプライン `/code:autopilot` を新設。plan 承認から PR Ready-to-merge までを自動連鎖する。併せてプラン作成を強制的に autopilot にルーティングする薄いラッパー `/code:plan` を追加し、`setup-dev-env` に 3 層 settings triage + CLAUDE.md 整合チェックを追加。

## パイプライン

```
/code:plan → plan file with autopilot directive → ExitPlanMode approval
  → /code:autopilot が自動起動
  → sprint-impl → audit-compliance → simplify → shipping-pr(--skip-review)
  → pr-review-team → retrospective
  → Ready-to-merge で停止（ユーザー指示でマージ）
```

停止条件: `critical + important = 0` AND `security pass` AND `CI SUCCESS`

## 主要変更

### Phase 1-A: shipping-pr 後方互換フラグ
- `--skip-review` 引数（default=false で既存動作維持）

### Phase 1-C: /code:plan 薄いラッパー
- built-in /plan mode の薄いラッパー
- plan file 先頭に autopilot 強制 directive を注入することで built-in /plan との決定的な振る舞い差を作る
- 自然言語で入力解釈（conversation / free text / Issue 参照 / interactive）

### Phase 1-D: /code:autopilot 本体
- auto mode 検出（3 層 settings heuristic + opt-in flag）
- 非対応時は refuse、dev-cycle 案内
- phase 遷移を Stop hook (`autopilot-stop.sh`) が強制
- state 管理: `.claude/autopilot.state.json`
- Stage 3.5: plan.issue が null なら `gh issue create`

### Phase 2: setup-dev-env 拡張（5 新 check）
- Check 9: auto mode heuristic
- Check 10: settings.local.json triage（個人依存は保全）
- Check 11: settings.json project triage（CLAUDE.md 整合確認）
- Check 12: plugins/*/.claude/settings.json 検査（読み取りのみ）
- Check 13: CLAUDE.md 整合チェック（diff 提示のみ）

### Phase 3: 後片付け
- retrospective の stale `approve-review.sh` 参照 → `set-review-flag.sh`
- `enforce-code-review-rules.sh` trigger 絞り込み（~50 → ~20 行、context 圧迫軽減）

## Issues

Closes #195 (shipping-pr --skip-review)
Closes #198 (/code:plan thin wrapper)
Closes #199 (plan frontmatter + directive spec)
Closes #201 (/code:autopilot command + skill)
Closes #202 (autopilot-stop.sh hook)
Closes #203 (auto-mode detection)
Closes #204 (state management)
Closes #205 (ensure-issue stage 3.5)
Closes #207 (setup-dev-env auto mode check)
Closes #208 (setup-dev-env local triage)
Closes #209 (setup-dev-env project triage)
Closes #210 (setup-dev-env plugin inspection)
Closes #211 (setup-dev-env CLAUDE.md integrity)
Closes #212 (stale approve-review.sh ref)
Closes #213 (enforce-code-review-rules narrowing)

## 設計判断

- 詳細プラン: `.claude/plans/autopilot-refactor-2026-04-18.md`（research 3系統 + CodeX + Advisor 統合）
- Flow D（会話 synthesis）が最頻ユースケースと識別、first-class citizen として対応
- simplify と pr-review-team は補完関係（PR #193 で実証、重複ではない）
- dev-cycle は legacy 維持、将来的な deprecation は Phase 4 として構想のみ（本 PR スコープ外）

## Test plan

- [ ] built-in /plan との差分確認（directive 注入あり）
- [ ] /code:autopilot が auto mode 検出しなければ refuse することを確認
- [ ] /code:plan "test" → plan 生成 → approval → autopilot 自動起動の E2E
- [ ] /code:setup-dev-env で 13 check 全て動作
- [ ] shipping-pr --skip-review で reviewer が起動しないことを確認
- [ ] 従来の /code:dev-cycle が変更影響を受けず動くこと（後方互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)