### PR TITLE
feat(code): switch to auto mode at EnterPlanMode via sentinel hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .claude/.context-budget.json
 .claude/dev-cycle-checkpoint.md
 .claude/dev-cycle.state.json
+.claude/*.flag
+.claude/autopilot.state.json
 
 # Playwright MCP
 .playwright-mcp/

--- a/plugins/code/hooks/hooks.json
+++ b/plugins/code/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "EnterPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-permission-on-enter.sh",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/plugins/code/scripts/autopilot-permission-on-enter.sh
+++ b/plugins/code/scripts/autopilot-permission-on-enter.sh
@@ -52,13 +52,20 @@ SENTINEL="$PROJECT_DIR/.claude/code-plan-pending.flag"
 [ -f "$SENTINEL" ] || exit 0
 
 # Consume the sentinel (one-shot) before emitting the decision. If the rm
-# fails (read-only filesystem, race with /code:plan's cleanup), fail-open
-# rather than double-apply.
-rm -f "$SENTINEL" 2>/dev/null || exit 0
+# fails for any reason other than a benign race (e.g. permission error,
+# path is a directory), log to stderr so Claude Code's hook diagnostics
+# surface the failure — otherwise the user sees no error but auto mode
+# silently fails to activate, which is the exact failure this hook exists
+# to prevent.
+if ! rm -f "$SENTINEL" 2>/dev/null; then
+  echo "autopilot-permission-on-enter: rm sentinel failed ($?) — skipping auto-mode injection" >&2
+  exit 0
+fi
 
 # Emit PermissionRequest allow decision with session-scoped setMode.
-# The hook output format is documented in Claude Code's hooks-guide
-# (auto-approve-specific-permission-prompts section).
+# Also log to stderr so operators can confirm the hook fired during
+# empirical testing of the undocumented setMode/mode:auto contract.
+echo "autopilot-permission-on-enter: emitting setMode auto (session)" >&2
 cat <<'JSON'
 {"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow","updatedPermissions":[{"type":"setMode","mode":"auto","destination":"session"}]}}}
 JSON

--- a/plugins/code/scripts/autopilot-permission-on-enter.sh
+++ b/plugins/code/scripts/autopilot-permission-on-enter.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# autopilot-permission-on-enter.sh — PermissionRequest hook that switches the
+# session permission mode to `auto` when entering plan mode from `/code:plan`.
+#
+# Why this exists:
+#   ExitPlanMode restores whatever permission mode was active just before
+#   EnterPlanMode. So if a user invokes `/code:plan` from a non-auto session,
+#   approval drops them back into non-auto — defeating autopilot's auto-mode
+#   requirement. By switching to auto AT the moment EnterPlanMode triggers a
+#   PermissionRequest, the "previous mode" that ExitPlanMode will restore to
+#   becomes auto.
+#
+# Trigger guard — the sentinel file:
+#   This hook must only act when the EnterPlanMode originates from /code:plan,
+#   not from the built-in /plan. The distinguishing signal is a sentinel file
+#   (`${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag`) written by the
+#   /code:plan skill just before it calls EnterPlanMode. If the sentinel is
+#   absent, emit nothing and exit 0 so built-in /plan behavior is unaffected.
+#
+# Sentinel lifecycle (one-shot):
+#   1. /code:plan writes the sentinel (Step 0.5)
+#   2. EnterPlanMode fires PermissionRequest, this hook reads + deletes sentinel
+#   3. If for any reason PermissionRequest never fires (e.g. already in auto),
+#      /code:plan's Step 1.5 deletes the sentinel unconditionally after
+#      EnterPlanMode returns, preventing leak into future built-in /plan calls.
+#
+# Design constraints (documented in the plan's Risks table):
+#   - Timing of setMode relative to EnterPlanMode's capture of the previous
+#     mode is undocumented. If it turns out EnterPlanMode snapshots "previous"
+#     before PermissionRequest decisions apply, this hook is a no-op. In that
+#     case the risk mitigation is to fall back to ExitPlanMode-time injection
+#     (separate design, not implemented here).
+#   - `mode: "auto"` acceptance by setMode is not in the public docs (which
+#     list default/acceptEdits/bypassPermissions). If silently rejected, the
+#     hook produces no visible behavior change. Empirical verification is
+#     required (see Phase 0 tests in plan generic-napping-bumblebee.md).
+#
+# Fail-open: any error produces no output + exit 0 so we never block or
+# corrupt a legitimate EnterPlanMode call.
+
+set -euo pipefail
+
+# Drain stdin (hooks receive JSON but this hook doesn't need to inspect it).
+cat >/dev/null 2>&1 || true
+
+# Resolve sentinel path. CLAUDE_PROJECT_DIR is provided by Claude Code for
+# hooks running in a project context.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+[ -n "$PROJECT_DIR" ] || exit 0
+
+SENTINEL="$PROJECT_DIR/.claude/code-plan-pending.flag"
+[ -f "$SENTINEL" ] || exit 0
+
+# Consume the sentinel (one-shot) before emitting the decision. If the rm
+# fails (read-only filesystem, race with /code:plan's cleanup), fail-open
+# rather than double-apply.
+rm -f "$SENTINEL" 2>/dev/null || exit 0
+
+# Emit PermissionRequest allow decision with session-scoped setMode.
+# The hook output format is documented in Claude Code's hooks-guide
+# (auto-approve-specific-permission-prompts section).
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow","updatedPermissions":[{"type":"setMode","mode":"auto","destination":"session"}]}}}
+JSON
+
+exit 0

--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -112,6 +112,15 @@ cmd_set() {
   [ -f "$STATE_FILE" ] || die "no state file; run init first"
   # Reject keys containing shell/jq metacharacters (defense against injection via arg)
   [[ "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid key: $key"
+  # Guard against bypassing the stop-hook's phase advance. Direct `set phase`
+  # skips the next-skill invocation step (the stop hook reads the current
+  # phase to pick NEXT_SKILL; manually jumping the phase forward silently
+  # omits the skill for the skipped phase — e.g. pr-review-team vanished
+  # when `set phase post-pr-review` was run after ship). `advance` is the
+  # intended API; direct `set phase` is reserved for resume-after-crash.
+  if [ "$key" = "phase" ] && [ -z "${AUTOPILOT_STATE_ALLOW_SET_PHASE:-}" ]; then
+    die "use 'advance' to move phases. Direct 'set phase' skips stop-hook skill dispatch. Set AUTOPILOT_STATE_ALLOW_SET_PHASE=1 only for manual recovery."
+  fi
   local now; now=$(iso_now)
   local tmp; tmp=$(mktemp)
   trap 'rm -f "$tmp"' RETURN

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -100,7 +100,7 @@ Both must be `0`. If not, `autopilot-stop.sh` cleans up state and exits. The use
 
 **State hygiene — do not manually advance `phase`**:
 
-The Stop hook owns `phase` transitions. It reads the current phase to pick `NEXT_SKILL`, invokes the next skill, and advances the state atomically (see `autopilot-stop.sh` switch). Manually running `autopilot-state.sh set phase ...` while the pipeline is in flight *skips the next-skill dispatch* for the intermediate phase. Concrete failure mode previously observed: running `set phase post-pr-review` after the ship phase caused the hook to read that phase and jump directly to retrospective — `pr-review-team` was never invoked, and the PR shipped without its post-merge review.
+The Stop hook owns `phase` transitions. It reads the current phase to pick `NEXT_SKILL`, invokes the next skill, and advances the state atomically (see `autopilot-stop.sh` switch). Manually running `autopilot-state.sh set phase ...` while the pipeline is in flight *skips the next-skill dispatch* for the intermediate phase. Concrete failure mode previously observed: while phase was still `ship` (before the Stop hook had advanced it to `post-pr-review`), running `set phase post-pr-review` caused the next Stop hook fire to read `post-pr-review` as the current phase and dispatch `code:retrospective` — `pr-review-team` was never invoked, and the PR shipped without its post-merge review.
 
 - ✅ OK: `autopilot-state.sh advance` (explicit single-step)
 - ✅ OK: `autopilot-state.sh set <non-phase-key> ...` (e.g. `last_successful_stage`, `issue_number`, `auto_mode_confidence`)

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -98,6 +98,14 @@ Both must be `0`. If not, `autopilot-stop.sh` cleans up state and exits. The use
 - If a phase fails (critical error, classifier block 3x, test failure):
   - Record the failure via `autopilot-state.sh set last_failure "..."` and exit the cycle cleanly. Do NOT retry indefinitely.
 
+**State hygiene — do not manually advance `phase`**:
+
+The Stop hook owns `phase` transitions. It reads the current phase to pick `NEXT_SKILL`, invokes the next skill, and advances the state atomically (see `autopilot-stop.sh` switch). Manually running `autopilot-state.sh set phase ...` while the pipeline is in flight *skips the next-skill dispatch* for the intermediate phase. Concrete failure mode previously observed: running `set phase post-pr-review` after the ship phase caused the hook to read that phase and jump directly to retrospective — `pr-review-team` was never invoked, and the PR shipped without its post-merge review.
+
+- ✅ OK: `autopilot-state.sh advance` (explicit single-step)
+- ✅ OK: `autopilot-state.sh set <non-phase-key> ...` (e.g. `last_successful_stage`, `issue_number`, `auto_mode_confidence`)
+- ❌ NOT OK: `autopilot-state.sh set phase ...` during normal flow — blocked by the script unless `AUTOPILOT_STATE_ALLOW_SET_PHASE=1` is set (reserved for manual resume-from-crash recovery)
+
 ## Step 4: Ready-to-merge stop
 
 After `retrospective` phase completes, the Stop hook cleans up the state file and allows stopping. At this point:

--- a/plugins/code/skills/plan/SKILL.md
+++ b/plugins/code/skills/plan/SKILL.md
@@ -13,12 +13,14 @@ argument-hint: [description or issue reference]
 **MANDATORY**: This skill is a thin wrapper around built-in `/plan` mode. Its distinguishing behavior is injecting an autopilot directive at the top of the generated plan file, ensuring that implementation goes through `/code:autopilot` pipeline.
 
 The leader MUST:
-1. Enter built-in plan mode via `EnterPlanMode` tool (Step 1)
-2. Interpret `$ARGUMENTS` as natural language to determine plan source (Step 2)
-3. Explore / synthesize / write plan file (Step 3)
-4. **Inject the autopilot directive at the top of the plan file** (Step 4, CRITICAL)
-5. Call `ExitPlanMode` to request user approval (Step 5)
-6. After approval, automatically invoke `/code:autopilot <plan-file>` (Step 6)
+1. **Create auto-mode sentinel** at `${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag` (Step 1, CRITICAL)
+2. Enter built-in plan mode via `EnterPlanMode` tool (Step 2)
+3. **Clean up sentinel** unconditionally after EnterPlanMode returns (Step 3, leak guard)
+4. Interpret `$ARGUMENTS` as natural language to determine plan source (Step 4)
+5. Explore / synthesize / write plan file (Step 5)
+6. **Inject the autopilot directive at the top of the plan file** (Step 6, CRITICAL)
+7. Call `ExitPlanMode` to request user approval (Step 7)
+8. After approval, automatically invoke `/code:autopilot <plan-file>` (Step 8)
 
 ## Input Interpretation
 
@@ -33,14 +35,25 @@ The leader MUST:
 
 **Ambiguity rule**: If the input could mean multiple things, ask a single clarifying question before entering plan mode.
 
-## Step 1: Enter Plan Mode
+## Step 1: Create Auto-Mode Sentinel (CRITICAL)
 
-Call the `EnterPlanMode` tool immediately. The built-in plan mode will provide:
-- A plan file path (e.g., `/Users/.../.claude/plans/<adjective-word-word>.md`)
-- Read-only restrictions (only the plan file is writable)
-- Phase structure: Initial Understanding → Design → Review → Final Plan → ExitPlanMode
+Use the `Write` tool to create an empty sentinel file at `${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag`. The full rationale (why ExitPlanMode restore timing requires this) lives in `plugins/code/scripts/autopilot-permission-on-enter.sh`'s header — the short version is that this sentinel signals the hook to switch the session to auto mode before `EnterPlanMode` captures its "previous mode".
 
-## Step 2: Interpret $ARGUMENTS
+Write the sentinel, then immediately call `EnterPlanMode` — no interleaved tool calls.
+
+## Step 2: Enter Plan Mode
+
+Call the `EnterPlanMode` tool. Built-in plan mode provides a plan file path (`/Users/.../.claude/plans/<adjective-word-word>.md`), read-only restrictions, and the Initial Understanding → Design → Review → Final Plan → ExitPlanMode phase structure.
+
+## Step 3: Sentinel Leak Guard
+
+Unconditionally remove the sentinel after `EnterPlanMode` returns — covers the case where no `PermissionRequest` fired (e.g., already in auto mode), preventing the flag from leaking into a future built-in `/plan` invocation:
+
+```bash
+rm -f "${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag"
+```
+
+## Step 4: Interpret $ARGUMENTS
 
 Based on the input pattern (see table above), identify the plan source:
 
@@ -50,7 +63,7 @@ Based on the input pattern (see table above), identify the plan source:
 
 **Free text**: Use the description directly as the seed for Goal and Acceptance. Ask clarifying questions if critical sections are unspecified.
 
-## Step 3: Explore and Synthesize (standard plan mode phases)
+## Step 5: Explore and Synthesize (standard plan mode phases)
 
 Follow the built-in plan mode workflow:
 - Launch Explore agents if code context is needed
@@ -66,7 +79,7 @@ Plan file sections (recommended):
 - **Risks** (known concerns, classifier blocks in auto mode)
 - **References** (related docs, Issues, PRs)
 
-## Step 4: Inject Autopilot Directive (CRITICAL)
+## Step 6: Inject Autopilot Directive (CRITICAL)
 
 **The plan file MUST begin with this directive block**, before any other content:
 
@@ -95,11 +108,11 @@ issue: <number>|null
 - `status` transitions: `draft` (during planning) → `ready` (when user approves via ExitPlanMode) → `in-progress` (autopilot picks up) → `done`.
 - `issue`: set to the Issue number if one exists; otherwise `null` (autopilot's Stage 3.5 will create one).
 
-## Step 5: Exit Plan Mode
+## Step 7: Exit Plan Mode
 
 Once the plan file is complete (including the directive and frontmatter), call `ExitPlanMode`. The user will review and approve.
 
-## Step 6: Auto-Invoke /code:autopilot (after approval)
+## Step 8: Auto-Invoke /code:autopilot (after approval)
 
 **MANDATORY after approval**: Immediately invoke `/code:autopilot` with the plan file path as argument. Do not ask "should I proceed?" — the directive at the top of the plan makes this step obligatory.
 
@@ -129,15 +142,15 @@ The manual sequence has no Stop hook enforcement, so transitions between skills 
 
 ## Error Handling
 
-- **User declines approval**: Exit cleanly. Do not proceed to Step 6.
-- **Issue fetch fails** (Step 2, issue-based): Fall back to asking the user for the Issue body or description.
+- **User declines approval**: Exit cleanly. Do not proceed to Step 8.
+- **Issue fetch fails** (Step 4, issue-based): Fall back to asking the user for the Issue body or description.
 - **`/code:autopilot` not available**: Log a warning in the summary and run manual pipeline equivalent.
 
 ## Important Notes
 
-- This skill is a **thin wrapper**. Its unique value is the directive injection (Step 4). All other steps delegate to built-in plan mode behavior.
-- Do NOT skip Step 4. Without the directive, this skill reduces to built-in `/plan`, defeating its purpose.
-- Do NOT skip Step 6 unconditionally. If the user explicitly asks to delay implementation, exit gracefully. Otherwise the directive is binding.
+- This skill is a **thin wrapper**. Its unique value is the directive injection (Step 6). All other steps delegate to built-in plan mode behavior.
+- Do NOT skip Step 6. Without the directive, this skill reduces to built-in `/plan`, defeating its purpose.
+- Do NOT skip Step 8 unconditionally. If the user explicitly asks to delay implementation, exit gracefully. Otherwise the directive is binding.
 - The directive is written in Japanese because the project's primary response language is Japanese. The structure (🔴 MANDATORY / 起動コマンド) matches conventions used in project CLAUDE.md.
 
 ## Related

--- a/plugins/code/skills/plan/SKILL.md
+++ b/plugins/code/skills/plan/SKILL.md
@@ -40,10 +40,12 @@ The leader MUST:
 Use the `Bash` tool to create the sentinel (the `mkdir -p` guards against fresh projects where `.claude/` does not yet exist — `Write` alone would fail silently in that case):
 
 ```bash
-mkdir -p "${CLAUDE_PROJECT_DIR}/.claude" && touch "${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag"
+mkdir -p "${CLAUDE_PROJECT_DIR}/.claude" && touch "${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag" && echo OK
 ```
 
-The full rationale (why ExitPlanMode restore timing requires this) lives in `plugins/code/scripts/autopilot-permission-on-enter.sh`'s header — the short version is that this sentinel signals the hook to switch the session to auto mode before `EnterPlanMode` captures its "previous mode".
+**Error handling**: the `&& echo OK` tail makes success observable. If the Bash tool returns a non-zero exit or omits `OK` (directory not writable, disk full, etc.), the sentinel was not created and the hook will not fire — **surface this failure to the user and do not proceed to Step 2**. Silent continuation would leave autopilot in non-auto mode.
+
+The sentinel signals the `PermissionRequest` hook (`autopilot-permission-on-enter.sh`) to emit a `setMode auto` decision during the `EnterPlanMode` permission flow. The precise timing of when `setMode` takes effect relative to `EnterPlanMode`'s snapshot of the previous mode is undocumented — see the hook script header for the full mechanism description and known risks.
 
 Create the sentinel, then immediately call `EnterPlanMode` — no interleaved tool calls.
 

--- a/plugins/code/skills/plan/SKILL.md
+++ b/plugins/code/skills/plan/SKILL.md
@@ -37,9 +37,15 @@ The leader MUST:
 
 ## Step 1: Create Auto-Mode Sentinel (CRITICAL)
 
-Use the `Write` tool to create an empty sentinel file at `${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag`. The full rationale (why ExitPlanMode restore timing requires this) lives in `plugins/code/scripts/autopilot-permission-on-enter.sh`'s header — the short version is that this sentinel signals the hook to switch the session to auto mode before `EnterPlanMode` captures its "previous mode".
+Use the `Bash` tool to create the sentinel (the `mkdir -p` guards against fresh projects where `.claude/` does not yet exist — `Write` alone would fail silently in that case):
 
-Write the sentinel, then immediately call `EnterPlanMode` — no interleaved tool calls.
+```bash
+mkdir -p "${CLAUDE_PROJECT_DIR}/.claude" && touch "${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag"
+```
+
+The full rationale (why ExitPlanMode restore timing requires this) lives in `plugins/code/scripts/autopilot-permission-on-enter.sh`'s header — the short version is that this sentinel signals the hook to switch the session to auto mode before `EnterPlanMode` captures its "previous mode".
+
+Create the sentinel, then immediately call `EnterPlanMode` — no interleaved tool calls.
 
 ## Step 2: Enter Plan Mode
 

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -18,7 +18,21 @@ fi
 shopt -s nullglob
 STATE_FILES=(/tmp/claude/pr-review-*.state)
 shopt -u nullglob
+
+# If no state file exists but the transcript shows pr-review-team was
+# launched, the skill skipped the mandatory `pr-review-state.sh init`
+# step — block stop so the leader surfaces the missing initialization.
+# Otherwise (no state + no pr-review-team evidence), this isn't a
+# pr-review-team session and we pass through.
 if [ ${#STATE_FILES[@]} -eq 0 ]; then
+    TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+    if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+        if grep -qE 'Launching skill: code:pr-review-team|code:pr-review-team' "$TRANSCRIPT_PATH" 2>/dev/null; then
+            printf 'pr-review-team ran without pr-review-state.sh init. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR>` at the start of the skill — iteration convergence cannot be verified without state.' \
+              | jq -Rs '{"decision":"block","reason":.}'
+            exit 0
+        fi
+    fi
     exit 0
 fi
 
@@ -36,7 +50,7 @@ fi
 STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
 
 # Extract state fields in a single jq call
-read -r SECURITY_DONE FIXER_DONE < <(echo "$STATE" | jq -r '[(.security_done // false | tostring), (.fixer_done // false | tostring)] | @tsv' 2>/dev/null || echo "false false")
+read -r SECURITY_DONE FIXER_DONE REREVIEW_DONE FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv' 2>/dev/null || echo "false false false -1 -1")
 
 # Load transcript once for all checks (avoid repeated file reads)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
@@ -65,6 +79,23 @@ if [ -n "$TRANSCRIPT" ]; then
             MISSING="${MISSING}\n- Fixer agent was not spawned (direct editing is prohibited)"
         fi
     fi
+fi
+
+# Check 3: After fixes, re-review must have happened (no self-declaring convergence).
+# The iteration contract: find issues → fix → re-run reviewers → record final counts.
+# Skipping re-review means the fix is unverified.
+if [ "$FIXER_DONE" = "true" ] && [ "$REREVIEW_DONE" != "true" ]; then
+    MISSING="${MISSING}\n- After fixer_done=true, re-review (iteration N+1) was not recorded. Re-run reviewers and call 'pr-review-state.sh set <PR> rereview_done true'."
+fi
+
+# Check 4: Convergence — final_critical and final_important must both be 0.
+# -1 means "not recorded yet"; any positive count means unresolved findings.
+if [ "$FINAL_CRITICAL" = "-1" ] || [ "$FINAL_IMPORTANT" = "-1" ]; then
+    if [ "$FIXER_DONE" = "true" ]; then
+        MISSING="${MISSING}\n- final_critical/final_important not recorded. Run 'pr-review-state.sh set <PR> final_critical <N>' and 'final_important <N>' after the last review."
+    fi
+elif [ "$FINAL_CRITICAL" != "0" ] || [ "$FINAL_IMPORTANT" != "0" ]; then
+    MISSING="${MISSING}\n- Convergence not reached (final_critical=${FINAL_CRITICAL}, final_important=${FINAL_IMPORTANT}). Run another fix+review iteration or report to user for manual decision."
 fi
 
 if [ -n "$MISSING" ]; then


### PR DESCRIPTION
Closes #215

## Summary

`/code:plan` 承認後の autopilot pipeline が permission prompt で停止する問題を修正。EnterPlanMode の PermissionRequest hook で session mode を auto に切り替えることで、ExitPlanMode 後も auto mode が維持されるようにした。

## 変更点

| File | 変更 |
|------|------|
| `plugins/code/scripts/autopilot-permission-on-enter.sh` (新規) | sentinel を検出して `setMode auto` を emit する PermissionRequest hook |
| `plugins/code/hooks/hooks.json` | PermissionRequest / EnterPlanMode matcher で新 hook を登録 |
| `plugins/code/skills/plan/SKILL.md` | Step 1 (sentinel 作成) / Step 3 (leak cleanup) を追加、全 step を 1-8 に整理 |
| `.gitignore` | `.claude/*.flag` と `.claude/autopilot.state.json` を ignore |

## 設計

- **Sentinel 方式**: `/code:plan` は `${CLAUDE_PROJECT_DIR}/.claude/code-plan-pending.flag` を `EnterPlanMode` 直前に作成し、直後に無条件削除。hook は sentinel 有無で built-in `/plan` と `/code:plan` を区別する
- **Fail-open**: sentinel 無し・env 未設定・rm 失敗時は全て no-op で exit 0
- **AC #6 (PreToolUse auto-approve hook)** は [PR #217](https://github.com/signalcompose/claude-tools/pull/217) で先行マージ済み

## Test plan

- [x] hook 単体: sentinel 有/無/`CLAUDE_PROJECT_DIR` 未設定の 3 ケース PASS
- [x] `hooks.json` JSON parse OK
- [ ] Phase 0 smoke test A: `setMode` timing が ExitPlanMode restore 対象の "previous mode" に適用されるか (マージ後 empirical 検証)
- [ ] Phase 0 smoke test B: `mode: "auto"` が setMode に受理されるか (同上)
- [ ] 正常系: non-auto session → `/code:plan` 起動 → plan 承認 → auto mode で autopilot が prompt なし完走
- [ ] 既 auto 環境: `/code:plan` 起動 → Step 3 が sentinel をクリーンアップ → leak なし
- [ ] built-in `/plan`: sentinel 無しで通常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)