### PR TITLE
docs(autopilot): sandbox bypass policy — do not use dangerouslyDisableSandbox

### DIFF
--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -130,12 +130,25 @@ To resume an interrupted cycle (new session, context recovered):
 
 The skill detects existing state and jumps to the recorded phase instead of reinitializing.
 
+## Sandbox bypass policy — do not use `dangerouslyDisableSandbox`
+
+The `Bash` tool accepts a `dangerouslyDisableSandbox: true` parameter. In auto mode this parameter **forces a user confirmation prompt** (auto mode intentionally refuses to auto-approve sandbox bypass, regardless of permission rules or hooks), breaking the autopilot flow. Empirical observations (2026-04-18):
+
+- `dangerouslyDisableSandbox` is evaluated on a layer *above* permission rules and PreToolUse hooks — neither can pre-approve it.
+- Auto mode's classifier auto-approves normal `Bash` calls (via `autoAllowBashIfSandboxed: true`) *inside* the sandbox; the plugin's `auto-approve-plugin-scripts.sh` hook further ensures plugin scripts pass without prompts.
+- Most operations the pipeline runs — `autopilot-state.sh` set/get, `autopilot-ensure-issue.sh`, `pr-review-state.sh`, `git`/`gh` CLI — touch only project-directory files and work correctly inside the sandbox. They do **not** need bypass.
+
+**Rule**: do not pass `dangerouslyDisableSandbox: true` from this skill or any phase it delegates to (sprint / simplify / ship / pr-review-team / retrospective). Let auto mode + the auto-approve hook handle permissions. The bypass is reserved for the narrow set of skills that genuinely need macOS audio/GUI system APIs (e.g. `cvi:speak` — which documents the requirement in its own skill file, tied to `say`/`afplay`/`osascript` failing inside the sandbox).
+
+If you encounter a bash command that actually fails inside the sandbox, surface the specific failure (filesystem / network / audio / etc.) before considering bypass. Defensive bypass on unrelated commands converts a silent auto-approval path into a blocking user prompt — which is exactly the regression this note exists to prevent.
+
 ## Important Notes
 
 - This skill runs **autonomously** in auto mode — no inter-phase confirmations
 - `/code:autopilot` is the **only authorized entry** for the full pipeline. Do NOT invoke `sprint-impl` → `audit-compliance` → ... manually in sequence outside autopilot.
 - The `skip_review` flag on `shipping-pr` is set automatically during the `ship` phase; do not set it manually.
 - The merge step (`gh pr merge`) is NEVER automatic. It requires explicit user instruction per CLAUDE.md rules.
+- **Do NOT pass `dangerouslyDisableSandbox: true`** on `Bash` tool calls. See the "Sandbox bypass policy" section above — the flag forces a blocking user prompt that auto mode intentionally refuses to auto-approve, breaking autopilot flow.
 - **When /code:autopilot is not available** (bootstrap): manually follow the pipeline in the same order. The plan directive's enforcement is via Claude's reading, not a runtime check.
 
 ## Related


### PR DESCRIPTION
## Summary

autopilot pipeline 中に agent が防御的に `dangerouslyDisableSandbox: true` を付けて、それが auto mode の auto-approve 範囲外でユーザー承認プロンプトを招き pipeline が止まる回帰の予防策。

## Context

2026-04-18 に orbitscore session で観測された事例: autopilot-state.sh の state 書き換え呼び出しに agent が自発的に `dangerouslyDisableSandbox: true` を付けてしまい、auto mode 中にもかかわらず "Do you want to proceed?" 承認プロンプトが発生して autopilot が停止した。

## Empirical facts

本 PR の判断根拠となった実測結果:

- `dangerouslyDisableSandbox` は permission 規則 + PreToolUse hook の上位レイヤで評価される。hook の `permissionDecision: allow` や literal `Bash(...)` allow rule では override 不可
- auto mode の classifier は `autoAllowBashIfSandboxed: true` の下で、sandbox 内 bash を auto-approve する
- autopilot pipeline が扱う大半の操作 (`autopilot-state.sh`, `pr-review-state.sh`, `git`, `gh`) は project dir 内 file 操作のみで sandbox 内で問題なく完走する
- `say` / `afplay` / `osascript` が sandbox 下で失敗する (CVI commit 89533c9 で検証済) のが唯一の正当な bypass 用途

## Changes

`plugins/code/skills/autopilot/SKILL.md`:

- 新セクション "Sandbox bypass policy — do not use `dangerouslyDisableSandbox`" を追加。flag が auto mode で必ず prompt を起こす理由、大半の pipeline 操作は bypass 不要な根拠、例外的な正当用途 (CVI 等) を明記
- "Important Notes" に短い警告 bullet を追加して discoverability を上げる

## Test plan

- [x] 単体: SKILL.md の markdown 構文を目視確認、既存セクション番号との整合性を確認
- [ ] 次回 autopilot 実行で agent が `dangerouslyDisableSandbox: true` を付けずに state 更新を行うこと (empirical, 次 session)

## Related

- PR #217 (auto-approve hook for plugin scripts)
- PR #218 (Issue #215 / autopilot permission fix)
- CVI commit 89533c9 (sandbox 下での macOS API 失敗)

🤖 Generated with [Claude Code](https://claude.com/claude-code)