### PR TITLE
fix(code): pr-review infrastructure usability for sandbox + merged-PR flows

### DIFF
--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -42,6 +42,16 @@ iso_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 
 die() { echo "autopilot-state: $*" >&2; exit 1; }
 
+# Create a temporary file next to $STATE_FILE rather than the default $TMPDIR.
+# Rationale: Claude Code's sandbox denies writes to /var/folders (the default
+# macOS TMPDIR) while allowing writes inside the project .claude/ directory.
+# Using the state file's dir keeps every write on the already-permitted path.
+state_mktemp() {
+  local dir; dir=$(dirname "$STATE_FILE")
+  mkdir -p "$dir"
+  mktemp "$dir/.autopilot.tmp.XXXXXX"
+}
+
 ensure_state_dir() {
   mkdir -p "$(dirname "$STATE_FILE")"
 }
@@ -122,7 +132,7 @@ cmd_set() {
     die "use 'advance' to move phases. Direct 'set phase' skips stop-hook skill dispatch. Set AUTOPILOT_STATE_ALLOW_SET_PHASE=1 only for manual recovery."
   fi
   local now; now=$(iso_now)
-  local tmp; tmp=$(mktemp)
+  local tmp; tmp=$(state_mktemp)
   trap 'rm -f "$tmp"' RETURN
   # Prefer --argjson (typed JSON). Fall back to --arg (string) if value is not valid JSON.
   # Single-pass write that also stamps updated_at; no secondary jq call.
@@ -144,7 +154,7 @@ cmd_advance() {
   local cur; cur=$(jq -r '.phase' "$STATE_FILE")
   local nxt; nxt=$(next_phase "$cur")
   local now; now=$(iso_now)
-  local tmp; tmp=$(mktemp)
+  local tmp; tmp=$(state_mktemp)
   trap 'rm -f "$tmp"' RETURN
   jq \
     --arg cur "$cur" \
@@ -164,7 +174,7 @@ cmd_metric() {
   [ -f "$STATE_FILE" ] || die "no state file"
   [[ "$name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid metric name: $name"
   local now; now=$(iso_now)
-  local tmp; tmp=$(mktemp)
+  local tmp; tmp=$(state_mktemp)
   trap 'rm -f "$tmp"' RETURN
   if jq --arg name "$name" --argjson v "$value" --arg now "$now" \
         '.metrics[$name] = $v | .updated_at = $now' \

--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -43,13 +43,16 @@ iso_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 die() { echo "autopilot-state: $*" >&2; exit 1; }
 
 # Create a temporary file next to $STATE_FILE rather than the default $TMPDIR.
-# Rationale: Claude Code's sandbox denies writes to /var/folders (the default
-# macOS TMPDIR) while allowing writes inside the project .claude/ directory.
-# Using the state file's dir keeps every write on the already-permitted path.
+# Claude Code's sandbox allow-list permits writes within the repository tree
+# (including the project's .claude/ directory) but denies the default macOS
+# $TMPDIR (/var/folders/...). Co-locating scratch files with the real state
+# keeps every write on an already-permitted path. Errors are surfaced via
+# stderr + non-zero return so callers' command substitution sees the failure
+# (bash's `local` swallows exit codes, hence the explicit `|| return 1`).
 state_mktemp() {
   local dir; dir=$(dirname "$STATE_FILE")
-  mkdir -p "$dir"
-  mktemp "$dir/.autopilot.tmp.XXXXXX"
+  mkdir -p "$dir" || { echo "autopilot-state: mkdir failed: $dir" >&2; return 1; }
+  mktemp "$dir/.autopilot.tmp.XXXXXX" || { echo "autopilot-state: mktemp failed in $dir" >&2; return 1; }
 }
 
 ensure_state_dir() {
@@ -132,7 +135,7 @@ cmd_set() {
     die "use 'advance' to move phases. Direct 'set phase' skips stop-hook skill dispatch. Set AUTOPILOT_STATE_ALLOW_SET_PHASE=1 only for manual recovery."
   fi
   local now; now=$(iso_now)
-  local tmp; tmp=$(state_mktemp)
+  local tmp; tmp=$(state_mktemp) || die "state_mktemp failed"
   trap 'rm -f "$tmp"' RETURN
   # Prefer --argjson (typed JSON). Fall back to --arg (string) if value is not valid JSON.
   # Single-pass write that also stamps updated_at; no secondary jq call.
@@ -154,7 +157,7 @@ cmd_advance() {
   local cur; cur=$(jq -r '.phase' "$STATE_FILE")
   local nxt; nxt=$(next_phase "$cur")
   local now; now=$(iso_now)
-  local tmp; tmp=$(state_mktemp)
+  local tmp; tmp=$(state_mktemp) || die "state_mktemp failed"
   trap 'rm -f "$tmp"' RETURN
   jq \
     --arg cur "$cur" \
@@ -174,7 +177,7 @@ cmd_metric() {
   [ -f "$STATE_FILE" ] || die "no state file"
   [[ "$name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid metric name: $name"
   local now; now=$(iso_now)
-  local tmp; tmp=$(state_mktemp)
+  local tmp; tmp=$(state_mktemp) || die "state_mktemp failed"
   trap 'rm -f "$tmp"' RETURN
   if jq --arg name "$name" --argjson v "$value" --arg now "$now" \
         '.metrics[$name] = $v | .updated_at = $now' \

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -16,6 +16,17 @@ fi
 
 STATE_DIR="/tmp/claude"
 STATE_FILE="${STATE_DIR}/pr-review-${PR_NUMBER}.state"
+DONE_FILE="${STATE_DIR}/pr-review-${PR_NUMBER}.done"
+
+# Create a temporary file inside $STATE_DIR rather than the default $TMPDIR.
+# Rationale: Claude Code's sandbox denies writes to /var/folders (the default
+# macOS TMPDIR) while allowing writes inside /tmp/claude once it's been
+# mkdir -p'd. Keeping scratch files alongside the real state avoids the
+# sandbox deny that broke `set` / `metric` in sandbox-enabled sessions.
+state_mktemp() {
+  mkdir -p "$STATE_DIR"
+  mktemp "${STATE_DIR}/.pr-review.tmp.XXXXXX"
+}
 
 case "$ACTION" in
   init)
@@ -34,7 +45,7 @@ case "$ACTION" in
       echo "ERROR: jq is required but not found" >&2
       exit 1
     fi
-    TMP=$(mktemp)
+    TMP=$(state_mktemp)
     trap 'rm -f "${TMP:-}"' EXIT
     jq --arg k "$KEY" --arg v "$VALUE" \
       '.[$k] = ($v | if . == "true" then true elif . == "false" then false else (try tonumber // .) end)' \
@@ -50,8 +61,26 @@ case "$ACTION" in
     cat "$STATE_FILE"
     ;;
   cleanup)
-    rm -f "$STATE_FILE"
-    echo "State cleaned up for PR #$PR_NUMBER"
+    # If the state shows a converged review (critical=0 AND important=0 AND
+    # rereview_done=true), preserve it as a `.done` marker so the Stop hook
+    # can recognize a legitimate completed review in future sessions — even
+    # after the transcript still carries evidence of the pr-review-team run.
+    # Otherwise (unconverged / missing fields), remove the state file
+    # unchanged — we don't want to leave misleading "done" markers for
+    # reviews that never finished.
+    if [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1 && \
+       jq -e '.final_critical == 0 and .final_important == 0 and .rereview_done == true' \
+          "$STATE_FILE" >/dev/null 2>&1; then
+      # mv -f: overwrite a prior .done for the same PR. The newer converged
+      # state supersedes any older marker — TTL-based GC in verify-workflow.sh
+      # would have pruned it eventually, but explicit overwrite here keeps
+      # behavior deterministic and avoids relying on mv's default.
+      mv -f "$STATE_FILE" "$DONE_FILE"
+      echo "State marked as .done for PR #$PR_NUMBER (converged)"
+    else
+      rm -f "$STATE_FILE"
+      echo "State cleaned up for PR #$PR_NUMBER"
+    fi
     ;;
   *)
     echo "Unknown action: $ACTION" >&2

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -19,13 +19,15 @@ STATE_FILE="${STATE_DIR}/pr-review-${PR_NUMBER}.state"
 DONE_FILE="${STATE_DIR}/pr-review-${PR_NUMBER}.done"
 
 # Create a temporary file inside $STATE_DIR rather than the default $TMPDIR.
-# Rationale: Claude Code's sandbox denies writes to /var/folders (the default
-# macOS TMPDIR) while allowing writes inside /tmp/claude once it's been
-# mkdir -p'd. Keeping scratch files alongside the real state avoids the
-# sandbox deny that broke `set` / `metric` in sandbox-enabled sessions.
+# Claude Code's sandbox allow-list permits writes within /tmp/claude (once
+# mkdir -p'd) but denies the default macOS $TMPDIR (/var/folders/...).
+# Co-locating scratch files with the real state avoids the sandbox deny
+# that broke `set` / `metric` in sandbox-enabled sessions. Errors are
+# surfaced via stderr + non-zero return so callers' command substitution
+# sees the failure (bash's `local`/assignment swallows exit codes).
 state_mktemp() {
-  mkdir -p "$STATE_DIR"
-  mktemp "${STATE_DIR}/.pr-review.tmp.XXXXXX"
+  mkdir -p "$STATE_DIR" || { echo "pr-review-state: mkdir failed: $STATE_DIR" >&2; return 1; }
+  mktemp "${STATE_DIR}/.pr-review.tmp.XXXXXX" || { echo "pr-review-state: mktemp failed in $STATE_DIR" >&2; return 1; }
 }
 
 case "$ACTION" in
@@ -45,7 +47,7 @@ case "$ACTION" in
       echo "ERROR: jq is required but not found" >&2
       exit 1
     fi
-    TMP=$(state_mktemp)
+    TMP=$(state_mktemp) || exit 1
     trap 'rm -f "${TMP:-}"' EXIT
     jq --arg k "$KEY" --arg v "$VALUE" \
       '.[$k] = ($v | if . == "true" then true elif . == "false" then false else (try tonumber // .) end)' \
@@ -75,7 +77,13 @@ case "$ACTION" in
       # state supersedes any older marker — TTL-based GC in verify-workflow.sh
       # would have pruned it eventually, but explicit overwrite here keeps
       # behavior deterministic and avoids relying on mv's default.
-      mv -f "$STATE_FILE" "$DONE_FILE"
+      # Failure (cross-device, permissions) must NOT be silent: if mv doesn't
+      # complete, the stale .state would be mistaken for an in-progress review
+      # in the next Stop hook fire.
+      mv -f "$STATE_FILE" "$DONE_FILE" || {
+        echo "ERROR: mv failed: $STATE_FILE -> $DONE_FILE" >&2
+        exit 1
+      }
       echo "State marked as .done for PR #$PR_NUMBER (converged)"
     else
       rm -f "$STATE_FILE"

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -198,4 +198,9 @@ Report summary:
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh cleanup <PR番号>
 ```
 
+`cleanup` の挙動は state の状態によって分岐:
+
+- **converged** (`final_critical=0` AND `final_important=0` AND `rereview_done=true`): `.state` → `.done` にリネーム。`verify-workflow.sh` (Stop hook) は `.done` を「完了済みレビュー」として認識し、後続 session で transcript に pr-review-team 起動痕跡があっても誤 block しない。`.done` は 24 時間後に TTL で自動削除
+- **未 converged**: `.state` を `rm -f` (従来通り)。完了していない review の痕跡を残さない
+
 No shutdown procedure needed — subagents complete automatically.

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -13,18 +13,61 @@ if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
     exit 0
 fi
 
-# Session detection via flag file (state file doubles as active-review flag)
-# If no state file exists, this is not a pr-review-team session → pass immediately
+# Session detection via flag file.
+#   .state → an in-progress review (active workflow)
+#   .done  → a completed, converged review preserved by cleanup
+# pass-through priority: if a matching .done exists we trust it (review was
+# properly completed earlier) and skip the workflow checks. Otherwise we look
+# for .state; if neither exists but transcript shows pr-review-team, block so
+# the leader surfaces the missing initialization.
+# Initialize arrays before the glob so `set -u` doesn't trip on empty matches
+# in bash 3.2 (macOS default). nullglob makes the pattern expand to nothing,
+# leaving the pre-initialized empty array intact — safe to count with `${#arr[@]}`.
+STATE_FILES=()
+DONE_FILES=()
 shopt -s nullglob
 STATE_FILES=(/tmp/claude/pr-review-*.state)
+DONE_FILES=(/tmp/claude/pr-review-*.done)
 shopt -u nullglob
 
-# If no state file exists but the transcript shows pr-review-team was
-# launched, the skill skipped the mandatory `pr-review-state.sh init`
-# step — block stop so the leader surfaces the missing initialization.
-# Otherwise (no state + no pr-review-team evidence), this isn't a
-# pr-review-team session and we pass through.
+NOW=$(date +%s)
+
+# Garbage-collect expired .done markers (24h) so they don't accumulate.
+# `.done` is auto-kept longer than `.state` (24h vs 1h) because it legitimately
+# spans multiple sessions — a merged PR's done marker needs to outlive the
+# session that produced it.
+DONE_MAX_AGE=86400
+if [ ${#DONE_FILES[@]} -gt 0 ]; then
+    for f in "${DONE_FILES[@]}"; do
+        mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)
+        if [ $((NOW - mtime)) -gt $DONE_MAX_AGE ]; then
+            rm -f "$f"
+        fi
+    done
+    # Rescan .done after GC
+    DONE_FILES=()
+    shopt -s nullglob
+    DONE_FILES=(/tmp/claude/pr-review-*.done)
+    shopt -u nullglob
+fi
+
+# Ordering is deliberate: if a `.state` exists we ALWAYS run the workflow
+# checks on it, even if an unrelated `.done` from a prior merged PR is still
+# present. Using `.done` to short-circuit here would let a stale marker from
+# PR X mask an in-progress, unconverged review of PR Y.
+#
+# `.done` pass-through only applies when there is NO active `.state` —
+# i.e. the session has no in-flight review and we're looking for whether to
+# credit a recently-completed one against the transcript evidence below.
+
+# If no .state either, decide between pass (no workflow in progress) and
+# block (pr-review-team launched without state init). A lingering `.done`
+# is treated as corroborating evidence that a review was properly completed
+# this session, so the transcript reference doesn't trigger a false block.
 if [ ${#STATE_FILES[@]} -eq 0 ]; then
+    if [ ${#DONE_FILES[@]} -gt 0 ]; then
+        exit 0
+    fi
     TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
     if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
         if grep -qE 'Launching skill: code:pr-review-team|code:pr-review-team' "$TRANSCRIPT_PATH" 2>/dev/null; then
@@ -40,7 +83,6 @@ fi
 STATE_FILE="${STATE_FILES[0]}"
 STATE_MAX_AGE=3600
 STATE_MTIME=$(stat -f %m "$STATE_FILE" 2>/dev/null || stat -c %Y "$STATE_FILE" 2>/dev/null || echo 0)
-NOW=$(date +%s)
 if [ $((NOW - STATE_MTIME)) -gt $STATE_MAX_AGE ]; then
     rm -f "$STATE_FILE"
     exit 0


### PR DESCRIPTION
Closes #224

## Summary

PR #218 で導入した enforcement 機構が実運用で 2 つの usability 回帰を起こしていたのを修正。

## 変更点

| File | 変更 |
|------|------|
| `plugins/code/scripts/autopilot-state.sh` | `state_mktemp()` helper を追加、3 箇所の `mktemp` を置換 |
| `plugins/code/scripts/pr-review-state.sh` | `state_mktemp()` 追加、`cleanup` を converge 判定付きリネームに変更、`jq -e` で型安全判定 |
| `plugins/code/skills/pr-review-team/scripts/verify-workflow.sh` | `.done` file 対応、24h TTL GC、`.state` 優先で cross-PR leak 防止、bash 3.2 対応 |
| `plugins/code/skills/pr-review-team/SKILL.md` | cleanup 挙動の docs 更新 |

## 修正する 2 問題

### 1. `mktemp` sandbox 失敗
macOS default TMPDIR (`/var/folders`) が sandbox で deny されるため set / metric / advance が全滅していた。既に書き込み許可されている state dir に tmp を作るよう変更。

### 2. merged PR transcript evidence での誤 block
`cleanup` が `rm -f` で state を消していたため、merge 後の session で「transcript evidence あり / state なし」で init 漏れ判定されていた。converge した state は `.done` にリネームして痕跡を残し、hook は `.done` で完了済み判定。

## Simplify 追加修正

- Stringly-typed converged check → `jq -e` exit code
- `mv` overwrite 明示 (`mv -f`)
- bash 3.2 empty array unbound variable 対策 (pre-init)

## Test plan

sandbox **有効**下で 4 シナリオ全 PASS:

- [x] empty state+done → pass (non-pr-review session)
- [x] no state+done + transcript evidence → block (init 漏れ検知)
- [x] converged `.done` + transcript → pass (完了済み認識)
- [x] `.done` for PR A + incomplete `.state` for PR B → workflow check on B (cross-PR leak 防止)

## Related

- PR #218: enforcement 機構の導入元
- Issue #224: 本 PR の tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)