### PR TITLE
fix: address shipping-pr YAML, pr-review-team false positive, and CVI lock path

### DIFF
--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -75,7 +75,9 @@ if [ ${#STATE_FILES[@]} -eq 0 ]; then
         # the skill listing injected into the session's system-reminder (available
         # skills), producing false positives in sessions that never invoked the
         # skill. See Issue #230.
-        if grep -qE 'Launching skill: code:pr-review-team' "$TRANSCRIPT_PATH" 2>/dev/null; then
+        # Word boundary on the right prevents matching a future sibling skill
+        # such as `code:pr-review-team-advanced`.
+        if grep -qE 'Launching skill: code:pr-review-team($|[^a-zA-Z0-9_-])' "$TRANSCRIPT_PATH" 2>/dev/null; then
             printf 'pr-review-team ran without pr-review-state.sh init. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR>` at the start of the skill — iteration convergence cannot be verified without state.' \
               | jq -Rs '{"decision":"block","reason":.}'
             exit 0

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -70,7 +70,12 @@ if [ ${#STATE_FILES[@]} -eq 0 ]; then
     fi
     TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
     if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-        if grep -qE 'Launching skill: code:pr-review-team|code:pr-review-team' "$TRANSCRIPT_PATH" 2>/dev/null; then
+        # Use a narrow match: only the explicit "Launching skill:" marker signals an
+        # actual invocation. The broader `code:pr-review-team` pattern also matched
+        # the skill listing injected into the session's system-reminder (available
+        # skills), producing false positives in sessions that never invoked the
+        # skill. See Issue #230.
+        if grep -qE 'Launching skill: code:pr-review-team' "$TRANSCRIPT_PATH" 2>/dev/null; then
             printf 'pr-review-team ran without pr-review-state.sh init. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR>` at the start of the skill — iteration convergence cannot be verified without state.' \
               | jq -Rs '{"decision":"block","reason":.}'
             exit 0

--- a/plugins/code/skills/shipping-pr/SKILL.md
+++ b/plugins/code/skills/shipping-pr/SKILL.md
@@ -5,7 +5,7 @@ description: |
   It loops until all critical/important review issues reach zero, then creates a PR.
   This skill should be used when the user says "ship it", "create PR", "commit and review", "出荷して", "PRお願い".
 user-invocable: true
-argument-hint: [--skip-review] [commit-message-hint]
+argument-hint: "[--skip-review] [commit-message-hint]"
 ---
 
 # Shipping PR

--- a/plugins/cvi/README.md
+++ b/plugins/cvi/README.md
@@ -352,7 +352,7 @@ afplay -v 1.0 /System/Library/Sounds/Ping.aiff &
 
 #### Phase 2: プロジェクト分離
 
-- **プロジェクト固有のロック**: `/tmp/cvi/${PROJECT_HASH}.lock`
+- **プロジェクト固有のロック**: `/tmp/claude/cvi/${PROJECT_HASH}.lock`
   - プロジェクトルートのMD5ハッシュ（16文字）でロックファイルを分離
   - `flock -w 30`で最大30秒待機（デッドロック防止）
 - **Sentinel Value**: "INITIALIZING"でrace conditionを軽減
@@ -375,7 +375,7 @@ afplay -v 1.0 /System/Library/Sounds/Ping.aiff &
 ### ファイル構成
 
 ```
-/tmp/cvi/
+/tmp/claude/cvi/
 ├── ${PROJECT_HASH}.lock         # プロジェクト別ロックファイル
 └── ${PROJECT_HASH}.lock.pid     # sayプロセスのPID記録
 

--- a/plugins/cvi/scripts/cleanup-stale-locks.sh
+++ b/plugins/cvi/scripts/cleanup-stale-locks.sh
@@ -10,7 +10,7 @@ debug_log() {
     fi
 }
 
-LOCK_DIR="/tmp/cvi"
+LOCK_DIR="/tmp/claude/cvi"
 ERROR_LOG="$HOME/.cvi/error.log"
 
 # Exit early if lock directory doesn't exist
@@ -33,7 +33,10 @@ debug_log "Starting stale lock cleanup in $LOCK_DIR"
 
 CHECKED=0
 # Use temp file for counting cleaned locks (subshell variable issue)
-CLEANED_COUNT_FILE="/tmp/cvi/cleanup_count.$$"
+CLEANED_COUNT_FILE="/tmp/claude/cvi/cleanup_count.$$"
+# Defensive mkdir: the early-exit guard above checks LOCK_DIR (same parent) but
+# protect against a race between the check and this write.
+mkdir -p "$(dirname "$CLEANED_COUNT_FILE")" 2>/dev/null
 echo "0" > "$CLEANED_COUNT_FILE"
 
 # Ensure temp file cleanup on exit

--- a/plugins/cvi/scripts/cleanup-stale-locks.sh
+++ b/plugins/cvi/scripts/cleanup-stale-locks.sh
@@ -34,10 +34,16 @@ debug_log "Starting stale lock cleanup in $LOCK_DIR"
 CHECKED=0
 # Use temp file for counting cleaned locks (subshell variable issue)
 CLEANED_COUNT_FILE="/tmp/claude/cvi/cleanup_count.$$"
-# Defensive mkdir: the early-exit guard above checks LOCK_DIR (same parent) but
-# protect against a race between the check and this write.
-mkdir -p "$(dirname "$CLEANED_COUNT_FILE")" 2>/dev/null
-echo "0" > "$CLEANED_COUNT_FILE"
+# Surface mkdir / write failures instead of silently continuing with a broken
+# counter (which would mask cleanup outcomes entirely).
+if ! mkdir -p "$(dirname "$CLEANED_COUNT_FILE")"; then
+    log_error "Failed to create parent directory for $CLEANED_COUNT_FILE"
+    exit 1
+fi
+if ! echo "0" > "$CLEANED_COUNT_FILE"; then
+    log_error "Failed to initialize $CLEANED_COUNT_FILE"
+    exit 1
+fi
 
 # Ensure temp file cleanup on exit
 trap 'rm -f "$CLEANED_COUNT_FILE"' EXIT

--- a/plugins/cvi/scripts/cvi-check
+++ b/plugins/cvi/scripts/cvi-check
@@ -37,24 +37,29 @@ echo -n "Siri音声: "
 if command -v say >/dev/null 2>&1; then
     # Use /tmp/claude (sandbox-writable prefix) so diagnostics run inside the
     # Claude Code sandbox without needing bypass. See Issue #231.
-    mkdir -p /tmp/claude
-    TEST_AUDIO="/tmp/claude/cvi_voice_test_$$.aiff"
-    say -o "$TEST_AUDIO" "test" 2>/dev/null
+    if ! mkdir -p /tmp/claude; then
+        # Surface the real cause instead of misattributing it to Siri below.
+        echo "❌ 作業ディレクトリを作成できませんでした: /tmp/claude"
+        SIRI_OK=false
+    else
+        TEST_AUDIO="/tmp/claude/cvi_voice_test_$$.aiff"
+        say -o "$TEST_AUDIO" "test" 2>/dev/null
 
-    if [ -f "$TEST_AUDIO" ]; then
-        FILE_SIZE=$(stat -f%z "$TEST_AUDIO" 2>/dev/null || echo "0")
-        rm -f "$TEST_AUDIO"
+        if [ -f "$TEST_AUDIO" ]; then
+            FILE_SIZE=$(stat -f%z "$TEST_AUDIO" 2>/dev/null || echo "0")
+            rm -f "$TEST_AUDIO"
 
-        if [ "$FILE_SIZE" -gt 10000 ]; then
-            echo "✅ 設定済み（推定）"
-            SIRI_OK=true
+            if [ "$FILE_SIZE" -gt 10000 ]; then
+                echo "✅ 設定済み（推定）"
+                SIRI_OK=true
+            else
+                echo "⚠️  未設定の可能性があります"
+                SIRI_OK=false
+            fi
         else
-            echo "⚠️  未設定の可能性があります"
+            echo "❌ 音声生成に失敗"
             SIRI_OK=false
         fi
-    else
-        echo "❌ 音声生成に失敗"
-        SIRI_OK=false
     fi
 else
     echo "❌ sayコマンドが見つかりません"

--- a/plugins/cvi/scripts/cvi-check
+++ b/plugins/cvi/scripts/cvi-check
@@ -35,7 +35,10 @@ echo ""
 # Check Siri voice
 echo -n "Siri音声: "
 if command -v say >/dev/null 2>&1; then
-    TEST_AUDIO="/tmp/cvi_voice_test_$$.aiff"
+    # Use /tmp/claude (sandbox-writable prefix) so diagnostics run inside the
+    # Claude Code sandbox without needing bypass. See Issue #231.
+    mkdir -p /tmp/claude
+    TEST_AUDIO="/tmp/claude/cvi_voice_test_$$.aiff"
     say -o "$TEST_AUDIO" "test" 2>/dev/null
 
     if [ -f "$TEST_AUDIO" ]; then

--- a/plugins/cvi/scripts/kill-voice.sh
+++ b/plugins/cvi/scripts/kill-voice.sh
@@ -33,6 +33,15 @@ debug_log "Project hash: $PROJECT_HASH"
 LOCK_DIR="/tmp/claude/cvi/${PROJECT_HASH}.lock"
 PID_FILE="${LOCK_DIR}/pid"
 
+# Migration compat: a session started before #231 fix may still hold a lock
+# at the old /tmp/cvi/ path. Fall back to the legacy location so kill-voice
+# can terminate in-flight audio rather than leaving it orphaned.
+LEGACY_LOCK_DIR="/tmp/cvi/${PROJECT_HASH}.lock"
+if [ ! -d "$LOCK_DIR" ] && [ -d "$LEGACY_LOCK_DIR" ]; then
+    LOCK_DIR="$LEGACY_LOCK_DIR"
+    PID_FILE="${LOCK_DIR}/pid"
+fi
+
 # If lock directory exists, read PID and kill the specific process
 if [ -d "$LOCK_DIR" ]; then
     if [ -f "$PID_FILE" ]; then

--- a/plugins/cvi/scripts/kill-voice.sh
+++ b/plugins/cvi/scripts/kill-voice.sh
@@ -30,7 +30,7 @@ PROJECT_HASH=$(echo "$PROJECT_ROOT" | md5 | cut -c1-16)
 debug_log "Project hash: $PROJECT_HASH"
 
 # Project-specific lock directory and PID file
-LOCK_DIR="/tmp/cvi/${PROJECT_HASH}.lock"
+LOCK_DIR="/tmp/claude/cvi/${PROJECT_HASH}.lock"
 PID_FILE="${LOCK_DIR}/pid"
 
 # If lock directory exists, read PID and kill the specific process

--- a/plugins/cvi/scripts/notify-input.sh
+++ b/plugins/cvi/scripts/notify-input.sh
@@ -19,9 +19,12 @@ PROJECT_HASH=$(echo "$PROJECT_ROOT" | md5 | cut -c1-16)
 
 # Project-specific lock directory
 LOCK_DIR="/tmp/claude/cvi/${PROJECT_HASH}.lock"
+# Migration compat: also check the legacy /tmp/cvi/ path (pre-#231 sessions)
+# so we don't start a duplicate notification while old audio is still playing.
+LEGACY_LOCK_DIR="/tmp/cvi/${PROJECT_HASH}.lock"
 
-# If lock directory exists, voice is playing, skip this notification
-if [ -d "$LOCK_DIR" ]; then
+# If a lock directory exists (new or legacy), voice is playing, skip this notification
+if [ -d "$LOCK_DIR" ] || [ -d "$LEGACY_LOCK_DIR" ]; then
     exit 0
 fi
 

--- a/plugins/cvi/scripts/notify-input.sh
+++ b/plugins/cvi/scripts/notify-input.sh
@@ -18,7 +18,7 @@ PROJECT_ROOT=$(pwd)
 PROJECT_HASH=$(echo "$PROJECT_ROOT" | md5 | cut -c1-16)
 
 # Project-specific lock directory
-LOCK_DIR="/tmp/cvi/${PROJECT_HASH}.lock"
+LOCK_DIR="/tmp/claude/cvi/${PROJECT_HASH}.lock"
 
 # If lock directory exists, voice is playing, skip this notification
 if [ -d "$LOCK_DIR" ]; then

--- a/plugins/cvi/scripts/post-speak.sh
+++ b/plugins/cvi/scripts/post-speak.sh
@@ -64,8 +64,13 @@ debug_log "Project root: $PROJECT_ROOT"
 PROJECT_HASH=$(echo "$PROJECT_ROOT" | md5 | cut -c1-16)
 debug_log "Project hash: $PROJECT_HASH"
 
-# Project-specific lock directory and PID file
-LOCK_DIR="/tmp/cvi/${PROJECT_HASH}.lock"
+# Project-specific lock directory and PID file.
+# Placed under /tmp/claude/ (Claude Code sandbox-writable prefix) so the skill
+# can acquire a lock without `dangerouslyDisableSandbox: true`. Previously
+# /tmp/cvi lived outside the sandbox write allowlist and forced bypass. See
+# Issue #231.
+LOCK_ROOT="/tmp/claude/cvi"
+LOCK_DIR="${LOCK_ROOT}/${PROJECT_HASH}.lock"
 PID_FILE="${LOCK_DIR}/pid"
 
 # Get script directory
@@ -75,7 +80,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 debug_log "Acquiring lock: $LOCK_DIR"
 
 # Ensure parent lock directory exists (may be cleaned on reboot)
-mkdir -p "/tmp/cvi"
+mkdir -p "$LOCK_ROOT"
 
 # Try to acquire lock (wait up to 30 seconds)
 TIMEOUT=30


### PR DESCRIPTION
## 概要

3 つの独立した bug fix を 1 PR にまとめて対応。本日のセッション中に発見/起票された Issue #228, #230, #231 を同時解決。

## 対応内容

### #228: shipping-pr SKILL.md の YAML 構文エラー

`plugins/code/skills/shipping-pr/SKILL.md` の `argument-hint` が YAML 無効構文（`[...]` が 2 つ並ぶ flow sequence）。Claude Code の lenient parser では通るが `gh skill publish` 等の strict parser では failure 判定。

**Fix**: 文字列としてクォート

```diff
-argument-hint: [--skip-review] [commit-message-hint]
+argument-hint: "[--skip-review] [commit-message-hint]"
```

### #230: pr-review-team Stop hook の false positive

`verify-workflow.sh` L73 の regex が Claude Code がセッション冒頭で注入する「利用可能スキル一覧」system-reminder の `code:pr-review-team` 行にマッチしてしまい、実際に skill を起動していないセッションでも block が発動していた。

**Fix**: 明示的な呼び出しシグナル（`Launching skill:` marker）のみ検出する regex に絞り込み。

### #231: CVI post-speak.sh の /tmp/cvi lock path が sandbox allowlist 外

Claude Code の sandbox は `/tmp/claude` を書き込み許可するが `/tmp/cvi` は拒否。CVI の全 lock/test path を `/tmp/claude/cvi/` 配下に移動。

**Fix**: 影響 script を一括更新
- `post-speak.sh`, `kill-voice.sh`, `notify-input.sh`, `cleanup-stale-locks.sh` の lock path 移動
- `cvi-check` のテスト audio path 移動
- `README.md` のパス記述更新
- `cleanup-stale-locks.sh` に defensive mkdir 追加（review findings 対応）

### 残存する制限（#231 の補足）

Lock dir 問題は解消したが、**audio IPC と osascript は依然として sandbox で block される**ため、`commands/speak.md` の `dangerouslyDisableSandbox: true` 指定は引き続き必要。

ただし user global の allow list + `skipAutoPermissionPrompt: true` の組み合わせで bypass prompt は自動承認されるため、auto mode の UX 改善はそちら側で達成されている（本日の実測で確認）。本 fix により `/tmp/claude/cvi/` 配下の lock 操作は sandbox 内で可能になったため、将来 audio permission が追加された際にスムーズに移行可能。

## Subtree considerations

`plugins/cvi/` は `signalcompose/cvi` の subtree 管理下ですが、本リポの運用方針 (memory: 「cvi ypm は下流で変更して upstream に同期でいい」) に従い本 PR 内で修正。マージ後 `git subtree push` で upstream 同期予定。

## Review

`/code:review-commit` 実行済み。code-reviewer agent による 1 iteration で:
- Critical: 0
- Important: 1 → 修正適用（cleanup-stale-locks.sh defensive mkdir）
- 残存 Important (confidence 80, borderline): cvi-check パス構造の整合性指摘 — 機能上無害のため本 PR では skip

## Test plan

- [x] #228: python3 yaml.safe_load で parse エラーが出ないこと
- [ ] #230: pr-review-team を起動していないセッションで Stop hook が block しないこと（デプロイ後）
- [x] #231: sandbox 内で post-speak.sh 実行時 "Cannot create lock directory" が出ないこと
- [ ] #231: CVI 再起動後も voice notification が従来通り動作すること（デプロイ後）

## Closes

Closes #228 #230 #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
