### PR TITLE
feat(cvi): add FastMCP speak server as interim sandbox-friendly path

### DIFF
--- a/plugins/cvi/.mcp.json
+++ b/plugins/cvi/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "cvi-voice": {
+      "command": "python3",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/mcp/server.py"
+      ]
+    }
+  }
+}

--- a/plugins/cvi/CLAUDE.md
+++ b/plugins/cvi/CLAUDE.md
@@ -221,6 +221,19 @@ cat ~/.claude/settings.json
 
 ## 技術仕様
 
+### Speak 実行経路（2 本立て）
+
+CVI の speak は **2 つの経路**を持つ（Issue #233 で MCP 経路を追加、bash 経路は互換のため温存）:
+
+| 経路 | 実装 | Sandbox | `dangerouslyDisableSandbox` |
+|------|------|---------|-----|
+| **MCP（優先）** | `mcp/server.py` (FastMCP, Python) | 外（subprocess） | 不要 |
+| **Bash（fallback）** | `scripts/post-speak.sh` → `speak-sync.sh` | 内 | 必要 |
+
+優先順位は `commands/speak.md` の指示に従い、`mcp__cvi-voice__speak` が利用可能なら MCP、
+失敗時は bash fallback。parrotvox が配布可能になったら speak.md の server 指定を
+`mcp__parrotvox__speak` に差し替えるだけで移行できる設計。
+
 ### 音声合成
 
 - **日本語**: `say -v Kyoko`（macOS標準）

--- a/plugins/cvi/README.md
+++ b/plugins/cvi/README.md
@@ -24,6 +24,8 @@ Claude Codeのタスク完了時に音声通知を行うシステム
 - **OS**: macOS（`say`, `afplay`コマンド使用）
 - **Claude Code**: 最新版
 - **権限**: スクリプト実行権限
+- **Python 3**: MCP server 経路で使用（標準の `python3` で可）
+- **`mcp` パッケージ**: `pip install mcp` （MCP server 経路が有効な場合のみ必須。Bash fallback のみで運用する場合は不要）
 
 ---
 
@@ -38,7 +40,18 @@ Claude Codeのプラグインシステムを使用してインストールでき
 /plugin add signalcompose/cvi
 ```
 
-これだけで完了です。hooks、コマンド、スキルが自動的に設定されます。
+これだけで完了です。hooks、コマンド、スキル、MCP server (`cvi-voice`) が自動的に設定されます。
+
+### MCP server の Python 依存
+
+MCP 経路を使う場合、初回のみ以下を実行してください:
+
+```bash
+pip install mcp
+```
+
+インストール省略でも Bash fallback（`dangerouslyDisableSandbox: true` 経由）で従来通り動作します。
+auto mode 下で permission prompt を出したくない場合は MCP 経路を推奨します。
 
 ### 初期設定
 

--- a/plugins/cvi/commands/speak.md
+++ b/plugins/cvi/commands/speak.md
@@ -5,15 +5,34 @@ user-invocable: false
 
 # CVI Speak
 
-テキストをCVI設定に従って読み上げます。
+テキストを CVI 設定に従って読み上げます。
 
-音声APIへのアクセスが必要なため、以下のBashコマンドを **`dangerouslyDisableSandbox: true`** で即座に実行してください:
+## 優先経路: MCP tool
+
+Claude Code に `mcp__cvi-voice__speak` が登録されている場合、**これを Skill tool 経由ではなく**
+**ツール呼び出しとして即座に実行してください**。引数:
+
+- `text`: `$ARGUMENTS` の内容
+- `voice`: 省略可（CVI config の per-language voice が使われる）
+- `rate`: 省略可（CVI config の SPEECH_RATE が使われる）
+
+MCP server は Claude Code の sandbox 外で動作するため、`dangerouslyDisableSandbox: true`
+は不要です。permission prompt も発生しません。
+
+## フォールバック: Bash 経路
+
+`mcp__cvi-voice__speak` が未登録、または呼び出しで失敗した場合のみ、以下の Bash コマンドを
+**`dangerouslyDisableSandbox: true`** で即座に実行してください:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/post-speak.sh "$ARGUMENTS"
 ```
 
-上記の結果を確認し、以下の形式でユーザーに表示してください（絵文字不可）:
+この経路は `say` / `afplay` / `osascript` への直接 IPC を必要とするため sandbox bypass が必須です。
+
+## 結果表示
+
+いずれの経路でも、ツールの返り値（`Speaking: <text>`）を以下の形式でユーザーに表示してください（絵文字不可）:
 
 ```
 Voice: "読み上げたテキスト"

--- a/plugins/cvi/commands/speak.md
+++ b/plugins/cvi/commands/speak.md
@@ -32,8 +32,12 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/post-speak.sh "$ARGUMENTS"
 
 ## 結果表示
 
-いずれの経路でも、ツールの返り値（`Speaking: <text>`）を以下の形式でユーザーに表示してください（絵文字不可）:
+以下の形式でユーザーに表示してください（絵文字不可）:
 
 ```
 Voice: "読み上げたテキスト"
 ```
+
+- **MCP 経路**: ツールの返り値は `Speaking: <text>` 形式。`<text>` 部分を上の `"読み上げたテキスト"` に入れて表示する
+- **Bash fallback 経路**: `post-speak.sh` の stdout にも `Speaking: <text>` が出力される（script 末尾で echo）ので、MCP 経路と同じ扱い
+- **CVI 無効（`CVI_ENABLED=off`）のとき**: MCP 経路は `CVI is disabled. Enable with: /cvi:state on` を文字列として返す。この場合は `Voice: "..."` ではなく、その案内文字列をそのまま表示する

--- a/plugins/cvi/mcp/server.py
+++ b/plugins/cvi/mcp/server.py
@@ -131,7 +131,10 @@ def speak(text: str, voice: str | None = None, rate: int | None = None) -> str:
     # Use the cached absolute path so the `_SAY_PATH is None` guard above
     # fully describes resolvability — avoids a second PATH lookup during
     # subprocess.run that could re-resolve under a changed environment.
-    cmd: list[str] = [_SAY_PATH, "-r", effective_rate]
+    # Local rebind narrows the module-level `str | None` to `str` for
+    # strict type-checkers; the None case has already raised.
+    say_path: str = _SAY_PATH
+    cmd: list[str] = [say_path, "-r", effective_rate]
     if effective_voice:
         cmd.extend(["-v", effective_voice])
     cmd.append(text)

--- a/plugins/cvi/mcp/server.py
+++ b/plugins/cvi/mcp/server.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+CVI Voice MCP Server — interim TTS server while parrotvox is in development.
+
+Exposes a single `speak` tool that invokes macOS `say` for text-to-speech.
+The tool signature deliberately mirrors the planned parrotvox MCP shape so
+the migration reduces to swapping the server registration.
+
+This server runs as a subprocess of Claude Code via .mcp.json registration
+and communicates over stdio JSON-RPC. Because MCP servers execute outside
+the Bash sandbox, `say` / `afplay` / `osascript` work without needing
+`dangerouslyDisableSandbox: true`.
+
+Fallback: if this server fails to start, the bundled bash post-speak.sh
+remains the speak path — see plugins/cvi/commands/speak.md.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("cvi-voice")
+
+
+CVI_CONFIG_PATH = Path.home() / ".cvi" / "config"
+
+# Resolve `say` once at module load. The binary ships with macOS and the path
+# is stable for the lifetime of the server process, so per-call PATH lookup
+# would be wasted work.
+_SAY_PATH = shutil.which("say")
+
+_CONFIG_DEFAULTS: dict[str, str] = {
+    "CVI_ENABLED": "on",
+    "VOICE_LANG": "en",
+    "SPEECH_RATE": "185",
+    "VOICE_EN": "Zoe",
+    "VOICE_JA": "Kyoko",
+    "VOICE_MODE": "auto",
+    "VOICE_FIXED": "",
+    "AUTO_DETECT_LANG": "true",
+}
+
+
+def _load_config() -> dict[str, str]:
+    """Read ~/.cvi/config shell-style KEY=VALUE lines. Missing file → defaults."""
+    cfg = dict(_CONFIG_DEFAULTS)
+    if not CVI_CONFIG_PATH.is_file():
+        return cfg
+    for raw in CVI_CONFIG_PATH.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        cfg[key.strip()] = value.strip().strip('"').strip("'")
+    return cfg
+
+
+def _detect_language(text: str) -> str:
+    """Return 'ja' if the text contains any Japanese Unicode range, else 'en'.
+
+    Ranges mirror ``speak-sync.sh`` (regex ``[ぁ-んァ-ヶー一-龠]``). Keep the two
+    implementations synchronized — divergence would silently pick different
+    voices for the same text across the MCP vs bash fallback paths.
+    """
+    for ch in text:
+        o = ord(ch)
+        # Hiragana, Katakana, CJK Unified Ideographs (see docstring above).
+        if 0x3040 <= o <= 0x309F or 0x30A0 <= o <= 0x30FF or 0x4E00 <= o <= 0x9FFF:
+            return "ja"
+    return "en"
+
+
+def _resolve_voice(cfg: dict[str, str], voice: str | None, lang: str) -> str | None:
+    """Resolve the voice name to pass to `say`. `None` → system default (no -v flag)."""
+    if voice:
+        return None if voice == "system" else voice
+    if cfg.get("VOICE_MODE") == "fixed" and cfg.get("VOICE_FIXED"):
+        fixed = cfg["VOICE_FIXED"]
+        return None if fixed == "system" else fixed
+    selected = cfg.get("VOICE_JA" if lang == "ja" else "VOICE_EN", "")
+    return None if selected in ("", "system") else selected
+
+
+@mcp.tool()
+def speak(text: str, voice: str | None = None, rate: int | None = None) -> str:
+    """
+    Speak `text` aloud via macOS `say`.
+
+    Args:
+        text: The string to speak. Empty string is an error.
+        voice: Optional voice name (e.g. "Zoe", "Kyoko"). "system" = default voice.
+            When None, the per-language voice from ~/.cvi/config is used.
+        rate: Optional words-per-minute. When None, SPEECH_RATE from config.
+
+    Returns:
+        A human-readable confirmation line ("Speaking: ...") compatible with the
+        existing hook contract used by plugins/cvi/commands/speak.md.
+    """
+    if not text.strip():
+        raise ValueError("text must be non-empty")
+
+    if _SAY_PATH is None:
+        raise RuntimeError("`say` command not found — CVI requires macOS")
+
+    cfg = _load_config()
+    if cfg.get("CVI_ENABLED", "on") == "off":
+        return "CVI is disabled. Enable with: /cvi:state on"
+
+    detected_lang = _detect_language(text) if cfg.get("AUTO_DETECT_LANG", "true") == "true" else cfg.get("VOICE_LANG", "en")
+    effective_rate = str(rate) if rate is not None else cfg.get("SPEECH_RATE", "185")
+    effective_voice = _resolve_voice(cfg, voice, detected_lang)
+
+    cmd: list[str] = ["say", "-r", effective_rate]
+    if effective_voice:
+        cmd.extend(["-v", effective_voice])
+    cmd.append(text)
+
+    # Fire and wait synchronously — callers expect voice to complete before
+    # the hook chain continues (matches bash post-speak.sh semantics).
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"say exited with status {exc.returncode}") from exc
+
+    return f"Speaking: {text}"
+
+
+if __name__ == "__main__":
+    # Transport defaults to stdio when invoked as a subprocess by Claude Code.
+    mcp.run()

--- a/plugins/cvi/mcp/server.py
+++ b/plugins/cvi/mcp/server.py
@@ -8,8 +8,10 @@ the migration reduces to swapping the server registration.
 
 This server runs as a subprocess of Claude Code via .mcp.json registration
 and communicates over stdio JSON-RPC. Because MCP servers execute outside
-the Bash sandbox, `say` / `afplay` / `osascript` work without needing
-`dangerouslyDisableSandbox: true`.
+the Bash sandbox, `say` works natively without needing
+`dangerouslyDisableSandbox: true`. (The notification / Glass-sound pieces
+that use `afplay` / `osascript` remain in the bash fallback — this server
+focuses on the speak tool only.)
 
 Fallback: if this server fails to start, the bundled bash post-speak.sh
 remains the speak path — see plugins/cvi/commands/speak.md.
@@ -17,9 +19,9 @@ remains the speak path — see plugins/cvi/commands/speak.md.
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -47,9 +49,20 @@ _CONFIG_DEFAULTS: dict[str, str] = {
 
 
 def _load_config() -> dict[str, str]:
-    """Read ~/.cvi/config shell-style KEY=VALUE lines. Missing file → defaults."""
+    """Read ~/.cvi/config shell-style KEY=VALUE lines. Missing file → defaults.
+
+    A missing config is a first-run / fresh-machine condition, not a hard
+    failure — CVI has no critical setting that requires an explicit value
+    to be safe. We warn once to stderr so new users see the path that was
+    checked and can run ``/cvi:setup`` if they expected a config file.
+    """
     cfg = dict(_CONFIG_DEFAULTS)
     if not CVI_CONFIG_PATH.is_file():
+        print(
+            f"[cvi-voice] config not found at {CVI_CONFIG_PATH}; "
+            "using defaults (CVI_ENABLED=on). Run /cvi:setup to generate one.",
+            file=sys.stderr,
+        )
         return cfg
     for raw in CVI_CONFIG_PATH.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
@@ -115,7 +128,10 @@ def speak(text: str, voice: str | None = None, rate: int | None = None) -> str:
     effective_rate = str(rate) if rate is not None else cfg.get("SPEECH_RATE", "185")
     effective_voice = _resolve_voice(cfg, voice, detected_lang)
 
-    cmd: list[str] = ["say", "-r", effective_rate]
+    # Use the cached absolute path so the `_SAY_PATH is None` guard above
+    # fully describes resolvability — avoids a second PATH lookup during
+    # subprocess.run that could re-resolve under a changed environment.
+    cmd: list[str] = [_SAY_PATH, "-r", effective_rate]
     if effective_voice:
         cmd.extend(["-v", effective_voice])
     cmd.append(text)

--- a/plugins/cvi/mcp/server.py
+++ b/plugins/cvi/mcp/server.py
@@ -39,7 +39,9 @@ _SAY_PATH = shutil.which("say")
 _CONFIG_DEFAULTS: dict[str, str] = {
     "CVI_ENABLED": "on",
     "VOICE_LANG": "en",
-    "SPEECH_RATE": "185",
+    # Aligned with bash `lib/config.sh` (default 200 wpm) — keep synchronized
+    # so switching between MCP and Bash fallback does not change voice pacing.
+    "SPEECH_RATE": "200",
     "VOICE_EN": "Zoe",
     "VOICE_JA": "Kyoko",
     "VOICE_MODE": "auto",


### PR DESCRIPTION
## 概要

CVI の speak を Bash tool + `dangerouslyDisableSandbox: true` 経路から MCP tool 経路に移行する interim 実装。MCP server は Claude Code sandbox の外で動作するため audio IPC (`say` / `afplay` / `osascript`) が bypass なしで通る。parrotvox が配布可能になるまでの移行期間を埋める目的。

## 背景

- Issue #233 で提起された通り、CVI の speak は現状 `dangerouslyDisableSandbox: true` を必要とし、auto mode で permission prompt を強制発生させる設計になっていた
- 本マシンでは `skipAutoPermissionPrompt: true` + allow list pattern match で auto-approve されていたが、**他マシンに portable な設定ではない**
- 最終解は parrotvox（CVI の MCP replacement、macOS native Swift app）だが、完成まで時間を要するため移行期間の interim が必要

## 変更内容

### 新規

- `plugins/cvi/mcp/server.py` — FastMCP ベースの speak server（~120 行）
  - **tool signature**: `speak(text, voice?, rate?)` — parrotvox の想定 signature に合わせ、将来の移行で `speak.md` の 1 行変更で完了する設計
  - `~/.cvi/config` 既存形式と互換（`CVI_ENABLED` / `VOICE_LANG` / `VOICE_EN` / `VOICE_JA` / `SPEECH_RATE` / `VOICE_MODE` / `VOICE_FIXED` / `AUTO_DETECT_LANG`）
  - 言語自動検出（Unicode range）は `speak-sync.sh` と同期させるコメントを両方に明記
  - `say` path を module load 時にキャッシュ → per-call PATH lookup を削減

- `plugins/cvi/.mcp.json` — MCP server の plugin 同梱登録
  ```json
  "cvi-voice": { "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/mcp/server.py"] }
  ```

### 更新

- `plugins/cvi/commands/speak.md` — **MCP 優先 / Bash fallback の 2 経路**指示。MCP 経路は `dangerouslyDisableSandbox` 不要、Bash 経路は従来通り（defense in depth）
- `plugins/cvi/README.md` — Python / `mcp` パッケージ依存の案内追加
- `plugins/cvi/CLAUDE.md` — "Speak 実行経路（2 本立て）" 技術仕様セクション追加

## 非目標（scope outside）

- bash `post-speak.sh` / `speak-sync.sh` の削除 → defense in depth として温存
- 言語自動検出 / queue 管理 / notification の統合 → parrotvox 移行で対応
- Python `mcp` パッケージの zero-install 化 → 将来検討

## Subtree considerations

`plugins/cvi/` は `signalcompose/cvi` の subtree 管理下。本 PR マージ後に `git subtree push --prefix=plugins/cvi https://github.com/signalcompose/cvi.git main` で upstream 同期予定。

## Review

本 PR は `/code:autopilot` の pipeline で構築:
- sprint → audit (DDD/TDD/DRY/ISSUE/PROCESS: PASS 4 / PARTIAL 1 許容)
- simplify → 3 agents 並列レビュー → Critical 0 / Important 0
  - 適用 fix: `say` path の module 初期化時キャッシュ、`_detect_language` 同期コメント追加
  - Skip: `_load_config` mtime cache（interim で over-engineering）、config parsing 重複（parrotvox 移行で解消）

post-pr-review (code:pr-review-team) は PR merge 前に実施予定。

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open("plugins/cvi/mcp/server.py").read())'` — syntax OK
- [x] `python3 -c 'import json; json.load(open("plugins/cvi/.mcp.json"))'` — JSON valid
- [ ] `pip install mcp` 後、plugin install → MCP server 起動 → `mcp__cvi-voice__speak` 動作確認（マージ後に別マシンで検証）
- [ ] 日本語 / 英語 / voice 指定 / rate 指定の各パターン確認

## 受け入れ条件

- [x] MCP server 実装存在（signature: `speak(text, voice, rate)`）
- [x] `.mcp.json` 登録
- [x] `speak.md` が MCP 優先 + bash fallback
- [x] bash `post-speak.sh` / `speak-sync.sh` 温存
- [x] config 既存形式と互換
- [x] parrotvox 移行時に 1 行差し替えで完了する設計

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
