### PR TITLE
fix(cvi): migrate MCP server launcher to uv for zero-install distribution

### DIFF
--- a/plugins/cvi/.mcp.json
+++ b/plugins/cvi/.mcp.json
@@ -1,8 +1,10 @@
 {
   "mcpServers": {
     "cvi-voice": {
-      "command": "python3",
+      "command": "uv",
       "args": [
+        "run",
+        "--script",
         "${CLAUDE_PLUGIN_ROOT}/mcp/server.py"
       ]
     }

--- a/plugins/cvi/mcp/server.py
+++ b/plugins/cvi/mcp/server.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "mcp>=1.0",
+# ]
+# ///
 """
 CVI Voice MCP Server — interim TTS server while parrotvox is in development.
 

--- a/plugins/cvi/mcp/server.py
+++ b/plugins/cvi/mcp/server.py
@@ -2,7 +2,9 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "mcp>=1.0",
+#     # Pin below 2.0 to guard against silent breakage on a future major
+#     # release (``from mcp.server.fastmcp import FastMCP`` could move).
+#     "mcp>=1.0,<2.0",
 # ]
 # ///
 """


### PR DESCRIPTION
## 概要

PR #234 で導入した CVI MCP server は `python3` 直接起動で `mcp` Python パッケージを user 環境に事前 install することを要求していたが、PEP 668 制約により `pip install mcp` が多くの macOS 環境で block されることが判明（本日の他マシン展開検証で判明）。

`uv run --script` + PEP 723 inline metadata に切り替えて**zero-install 化**。user の Python 環境を汚染せず、`uv` さえあれば（macOS は `brew install uv` で広く普及）動く。

## 変更

### `plugins/cvi/.mcp.json`

```diff
-  "command": "python3",
-  "args": ["${CLAUDE_PLUGIN_ROOT}/mcp/server.py"]
+  "command": "uv",
+  "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/mcp/server.py"]
```

### `plugins/cvi/mcp/server.py` 冒頭

```python
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "mcp>=1.0",
# ]
# ///
```

PEP 723 inline script metadata により、`uv run --script` が隔離された temporary venv に依存を自動展開する。

## なぜ `python3` から `uv` に変えるか

| 観点 | `python3` | `uv run --script` |
|---|---|---|
| 追加 install | `pip install mcp` 必要 | **不要** |
| PEP 668 衝突 | あり (brew / Xcode Python で block) | 回避 |
| 環境汚染 | user site-packages に混入 | per-invocation 隔離 venv |
| 他マシン展開 | user 毎に手動 install | `brew install uv` 一度で済む |
| 初回起動時間 | 即座 | 初回 ~2 秒（dep resolve + install） |
| 2 回目以降 | 即座 | 即座（cached） |

## 検証

- `uv run --script plugins/cvi/mcp/server.py < /dev/null` 起動で:
  - 29 packages install (初回のみ)
  - 2 回目以降は 41ms 起動（cached）
- `.mcp.json` JSON schema 有効
- `server.py` AST parse OK
- parrotvox 移行時の signature 一致は維持（`speak(text, voice, rate)`）

## Subtree considerations

`plugins/cvi/` は `signalcompose/cvi` の subtree 管理下。マージ後 `git subtree push` で upstream 同期予定。

## 前提

`uv` が PATH に存在すること。macOS 向け:
```bash
brew install uv
```

## 関連

- PR #234 で導入した MCP server path の zero-install 化
- Issue #233（CVI MCP 移行）の受け入れ条件 "parrotvox 移行時 1 行変更" は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)
