### PR TITLE
fix(code): bind pr-review-team state to project_path to prevent cross-session false blocks

### DIFF
--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -50,7 +50,7 @@ case "$ACTION" in
       PROJECT_PATH_ESC="${PROJECT_PATH_ESC//\"/\\\"}"
       SESSION_ID_ESC="${SESSION_ID//\\/\\\\}"
       SESSION_ID_ESC="${SESSION_ID_ESC//\"/\\\"}"
-      printf '{"pr":"%s","session_id":"%s","project_path":"%s","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"iterations":0,"final_critical":-1,"final_important":-1}' \
+      printf '{"pr":"%s","session_id":"%s","project_path":"%s","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"bot_feedback_read":false,"iterations":0,"final_critical":-1,"final_important":-1}' \
         "$PR_NUMBER" "$SESSION_ID_ESC" "$PROJECT_PATH_ESC" > "$STATE_FILE"
     else
       jq -n \
@@ -59,7 +59,8 @@ case "$ACTION" in
         --arg project "$PROJECT_PATH" \
         '{pr:$pr, session_id:$session, project_path:$project, phase:"started",
           reviewers_done:false, security_done:false, fixer_done:false,
-          rereview_done:false, iterations:0, final_critical:-1, final_important:-1}' \
+          rereview_done:false, bot_feedback_read:false,
+          iterations:0, final_critical:-1, final_important:-1}' \
         > "$STATE_FILE"
     fi
     echo "State initialized for PR #$PR_NUMBER"

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -43,9 +43,10 @@ case "$ACTION" in
     SESSION_ID="${CLAUDE_SESSION_ID:-}"
     if ! command -v jq >/dev/null 2>&1; then
       # jq unavailable: fall back to printf. Escape backslash and double-quote
-      # to keep the emitted JSON valid even for unusual filesystem paths. We
-      # do not attempt full JSON escape (control chars, unicode) since POSIX
-      # filesystem conventions disallow those in directory names.
+      # so the emitted JSON stays valid for typical filesystem paths and
+      # session IDs. This fallback does not implement full JSON string
+      # escaping (control chars, embedded newlines, etc.); if those appear
+      # in a path the caller should install jq.
       PROJECT_PATH_ESC="${PROJECT_PATH//\\/\\\\}"
       PROJECT_PATH_ESC="${PROJECT_PATH_ESC//\"/\\\"}"
       SESSION_ID_ESC="${SESSION_ID//\\/\\\\}"

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -33,7 +33,30 @@ state_mktemp() {
 case "$ACTION" in
   init)
     mkdir -p "$STATE_DIR"
-    printf '{"pr":"%s","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"iterations":0,"final_critical":-1,"final_important":-1}' "$PR_NUMBER" > "$STATE_FILE"
+    # Record project_path so verify-workflow.sh can skip state files left by
+    # unrelated projects (Issue #236). `pwd -P` resolves symlinks for stable
+    # comparison; trailing slashes are stripped by pwd by default.
+    # session_id is recorded as supplementary telemetry — verify-workflow.sh
+    # currently keys off project_path only, but storing session_id now keeps
+    # future debug / cross-session correlation cheap.
+    PROJECT_PATH="$(pwd -P)"
+    SESSION_ID="${CLAUDE_SESSION_ID:-}"
+    if ! command -v jq >/dev/null 2>&1; then
+      # jq unavailable: fall back to printf with manual escaping.
+      # Slashes in paths are JSON-safe; we assume no double-quote in paths
+      # (macOS / Linux project paths don't contain ").
+      printf '{"pr":"%s","session_id":"%s","project_path":"%s","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"iterations":0,"final_critical":-1,"final_important":-1}' \
+        "$PR_NUMBER" "$SESSION_ID" "$PROJECT_PATH" > "$STATE_FILE"
+    else
+      jq -n \
+        --arg pr "$PR_NUMBER" \
+        --arg session "$SESSION_ID" \
+        --arg project "$PROJECT_PATH" \
+        '{pr:$pr, session_id:$session, project_path:$project, phase:"started",
+          reviewers_done:false, security_done:false, fixer_done:false,
+          rereview_done:false, iterations:0, final_critical:-1, final_important:-1}' \
+        > "$STATE_FILE"
+    fi
     echo "State initialized for PR #$PR_NUMBER"
     ;;
   set)

--- a/plugins/code/scripts/pr-review-state.sh
+++ b/plugins/code/scripts/pr-review-state.sh
@@ -39,14 +39,19 @@ case "$ACTION" in
     # session_id is recorded as supplementary telemetry — verify-workflow.sh
     # currently keys off project_path only, but storing session_id now keeps
     # future debug / cross-session correlation cheap.
-    PROJECT_PATH="$(pwd -P)"
+    PROJECT_PATH="$(pwd -P 2>/dev/null || pwd)"
     SESSION_ID="${CLAUDE_SESSION_ID:-}"
     if ! command -v jq >/dev/null 2>&1; then
-      # jq unavailable: fall back to printf with manual escaping.
-      # Slashes in paths are JSON-safe; we assume no double-quote in paths
-      # (macOS / Linux project paths don't contain ").
+      # jq unavailable: fall back to printf. Escape backslash and double-quote
+      # to keep the emitted JSON valid even for unusual filesystem paths. We
+      # do not attempt full JSON escape (control chars, unicode) since POSIX
+      # filesystem conventions disallow those in directory names.
+      PROJECT_PATH_ESC="${PROJECT_PATH//\\/\\\\}"
+      PROJECT_PATH_ESC="${PROJECT_PATH_ESC//\"/\\\"}"
+      SESSION_ID_ESC="${SESSION_ID//\\/\\\\}"
+      SESSION_ID_ESC="${SESSION_ID_ESC//\"/\\\"}"
       printf '{"pr":"%s","session_id":"%s","project_path":"%s","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"iterations":0,"final_critical":-1,"final_important":-1}' \
-        "$PR_NUMBER" "$SESSION_ID" "$PROJECT_PATH" > "$STATE_FILE"
+        "$PR_NUMBER" "$SESSION_ID_ESC" "$PROJECT_PATH_ESC" > "$STATE_FILE"
     else
       jq -n \
         --arg pr "$PR_NUMBER" \

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -169,17 +169,42 @@ FOR iteration = 1 TO MAX_ITERATIONS:
 
   4. Collect fresh counts: fresh_critical, fresh_important, fresh_security
 
-  5. Update state:
+  5. Read GitHub bot feedback (claude-review Check Run + PR review comments)
+     before declaring convergence. The Stop hook enforces this via transcript
+     inspection — the leader MUST invoke at least one of:
+
+       gh pr view <PR> --json reviews,comments
+       gh api repos/OWNER/REPO/pulls/<PR>/comments
+       gh api repos/OWNER/REPO/check-runs/<id>/annotations
+
+     Then record:
+       bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR> bot_feedback_read true
+
+     Bot findings (if any) are merged into the next iteration's fixer message.
+
+  6. Update state:
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> fixer_done true
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> iterations <N>
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> final_critical <count>
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> final_important <count>
 
-  6. IF fresh_critical = 0 AND fresh_important = 0 AND fresh_security = "all_pass" → BREAK
+  7. IF fresh_critical = 0 AND fresh_important = 0 AND fresh_security = "all_pass" → BREAK
 END FOR
 ```
 
 If iteration limit reached with remaining issues: report to user, do NOT merge.
+
+🔴 VIOLATION — Self-declaring Convergence Without Evidence
+The Stop hook enforces (Issue #236 follow-up):
+- `rereview_done=true` requires the transcript to show ≥2
+  `pr-review-toolkit:code-reviewer` agent launches (initial + post-fix
+  re-review). Manually setting `rereview_done=true` without spawning a fresh
+  reviewer agent is a workflow violation — the leader would otherwise judge
+  their own fix without independent verification.
+- `bot_feedback_read=true` requires either the state flag to be set after
+  actually consulting GitHub bot output, or the transcript to contain a
+  matching `gh pr view --json reviews/comments`, `gh api .../pulls/N/comments`,
+  or `gh api .../check-runs/.../annotations` call.
 
 ## Step 6: Report & Cleanup
 

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -182,8 +182,13 @@ FOR iteration = 1 TO MAX_ITERATIONS:
 
      Bot findings (if any) are merged into the next iteration's fixer message.
 
-  6. Update state:
+  6. Update state. `rereview_done` MUST be set at the end of the iteration
+     — i.e. after the fresh reviewer agent in step 3 of THIS iteration has
+     returned. Setting it before re-running the reviewer is a violation
+     (see the VIOLATION block below — the Stop hook will detect it via
+     transcript launch count).
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> fixer_done true
+     bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> rereview_done true
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> iterations <N>
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> final_critical <count>
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> final_important <count>

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -98,8 +98,28 @@ fi
 # Read progress from state file
 STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
 
-# Extract state fields in a single jq call
-read -r SECURITY_DONE FIXER_DONE REREVIEW_DONE FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv' 2>/dev/null || echo "false false false -1 -1")
+# Extract all state fields in a single jq call — includes project_path for
+# the Issue #236 cross-project binding check alongside the workflow fields.
+read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv' 2>/dev/null || echo $'\tfalse\tfalse\tfalse\t-1\t-1')
+
+# Project binding check (Issue #236): skip state files that belong to a
+# different project. Without this, a stale state from session A (working on
+# project /foo) would block Stop in session B (working on project /bar). We
+# do NOT delete mismatched states here — the owning session may still be
+# active and will clean up on its own; TTL-based GC above handles truly
+# abandoned ones. `pwd -P` resolves symlinks so a checkout accessed via a
+# symlinked path still matches the canonical path recorded at init time.
+CURRENT_PROJECT="$(pwd -P 2>/dev/null || pwd)"
+if [ -n "$STATE_PROJECT" ] && [ "$STATE_PROJECT" != "$CURRENT_PROJECT" ]; then
+    # State belongs to another project — not our concern, let Stop proceed.
+    exit 0
+fi
+# Legacy state files (pre-#236) lack project_path. Treat them as safe to
+# ignore for Stop purposes — the TTL cleanup above removes them eventually.
+# Blocking on them causes the exact bug Issue #236 describes.
+if [ -z "$STATE_PROJECT" ]; then
+    exit 0
+fi
 
 # Load transcript once for all checks (avoid repeated file reads)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -111,7 +111,7 @@ fi
 
 # Extract all state fields in a single jq call — includes project_path for
 # the Issue #236 cross-project binding check alongside the workflow fields.
-read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv')
+read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE BOT_FEEDBACK_READ FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.bot_feedback_read // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv')
 
 # Project binding check (Issue #236): skip state files that belong to a
 # different project. Without this, a stale state from session A (working on
@@ -168,6 +168,32 @@ fi
 # Skipping re-review means the fix is unverified.
 if [ "$FIXER_DONE" = "true" ] && [ "$REREVIEW_DONE" != "true" ]; then
     MISSING="${MISSING}\n- After fixer_done=true, re-review (iteration N+1) was not recorded. Re-run reviewers and call 'pr-review-state.sh set <PR> rereview_done true'."
+fi
+
+# Check 3b: rereview_done=true must be backed by transcript evidence of at
+# least 2 reviewer agent launches (initial + post-fix). This prevents the
+# leader from self-declaring convergence by flipping the flag without
+# actually re-running the reviewers — which is effectively "judging your own
+# fix without independent verification" and defeats the purpose of Step 5.
+if [ "$FIXER_DONE" = "true" ] && [ "$REREVIEW_DONE" = "true" ] && [ -n "$TRANSCRIPT" ]; then
+    REVIEWER_LAUNCHES=$(echo "$TRANSCRIPT" | grep -cE '"subagent_type":[[:space:]]*"pr-review-toolkit:code-reviewer"' 2>/dev/null || echo 0)
+    if [ "$REVIEWER_LAUNCHES" -lt 2 ]; then
+        MISSING="${MISSING}\n- rereview_done=true but transcript shows only ${REVIEWER_LAUNCHES} code-reviewer agent launch(es). Re-review requires a fresh reviewer invocation after the fix, not state manipulation."
+    fi
+fi
+
+# Check 3c: Before declaring convergence the leader must have consulted
+# GitHub bot feedback (claude-review check-run annotations, PR review
+# comments). Accept either an explicit state flag or transcript evidence
+# of a matching gh command — otherwise block so the leader runs the check.
+if [ "$FIXER_DONE" = "true" ] && [ "$BOT_FEEDBACK_READ" != "true" ]; then
+    if [ -n "$TRANSCRIPT" ]; then
+        if ! echo "$TRANSCRIPT" | grep -qE 'gh pr view [^|]*--json[^|]*(reviews|comments)|gh api [^|]*pulls/[0-9]+/(comments|reviews)|gh api [^|]*check-runs/[0-9]+/annotations' 2>/dev/null; then
+            MISSING="${MISSING}\n- Bot feedback (claude-review check / PR review comments) was not read. Run 'gh pr view <PR> --json reviews,comments' or equivalent, then 'pr-review-state.sh set <PR> bot_feedback_read true'."
+        fi
+    else
+        MISSING="${MISSING}\n- bot_feedback_read=false and transcript unavailable — cannot verify bot feedback was consulted."
+    fi
 fi
 
 # Check 4: Convergence — final_critical and final_important must both be 0.

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -98,9 +98,20 @@ fi
 # Read progress from state file
 STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
 
+# Validate STATE is parseable JSON before field extraction. A corrupt / empty
+# / truncated state file would otherwise produce an empty STATE_PROJECT via
+# the `//` fallback, which the legacy-state branch below would silently
+# interpret as "no binding" and skip — masking a genuine in-progress review.
+# On indeterminate data we skip (TTL-based GC removes the file eventually)
+# rather than block, because raising a hard error on a race-induced truncated
+# state would create a different false-block pattern.
+if ! echo "$STATE" | jq -e . >/dev/null 2>&1; then
+    exit 0
+fi
+
 # Extract all state fields in a single jq call — includes project_path for
 # the Issue #236 cross-project binding check alongside the workflow fields.
-read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv' 2>/dev/null || echo $'\tfalse\tfalse\tfalse\t-1\t-1')
+read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv')
 
 # Project binding check (Issue #236): skip state files that belong to a
 # different project. Without this, a stale state from session A (working on
@@ -114,9 +125,11 @@ if [ -n "$STATE_PROJECT" ] && [ "$STATE_PROJECT" != "$CURRENT_PROJECT" ]; then
     # State belongs to another project — not our concern, let Stop proceed.
     exit 0
 fi
-# Legacy state files (pre-#236) lack project_path. Treat them as safe to
-# ignore for Stop purposes — the TTL cleanup above removes them eventually.
-# Blocking on them causes the exact bug Issue #236 describes.
+# Legacy state files (pre-#236) genuinely lack a project_path field. Since we
+# validated JSON above, an empty STATE_PROJECT at this point reflects the
+# real schema rather than a parse failure. Treat legacy state as safe to
+# ignore for Stop purposes — blocking on it causes the exact Issue #236
+# regression. The TTL cleanup above removes legacy files eventually.
 if [ -z "$STATE_PROJECT" ]; then
     exit 0
 fi

--- a/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
+++ b/plugins/code/skills/pr-review-team/scripts/verify-workflow.sh
@@ -86,53 +86,64 @@ if [ ${#STATE_FILES[@]} -eq 0 ]; then
     exit 0
 fi
 
-# TTL check: stale state files (>1 hour) are from dead sessions — clean up and allow stop
-STATE_FILE="${STATE_FILES[0]}"
 STATE_MAX_AGE=3600
-STATE_MTIME=$(stat -f %m "$STATE_FILE" 2>/dev/null || stat -c %Y "$STATE_FILE" 2>/dev/null || echo 0)
-if [ $((NOW - STATE_MTIME)) -gt $STATE_MAX_AGE ]; then
-    rm -f "$STATE_FILE"
-    exit 0
-fi
+CURRENT_PROJECT="$(pwd -P 2>/dev/null || pwd)"
 
-# Read progress from state file
-STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "{}")
+# Select the state file belonging to the current project. The previous
+# single-slot approach (STATE_FILES[0]) was unsafe: if a stale state from
+# project A sorted before project B's active state, we would early-exit on
+# the A mismatch and silently skip B's workflow checks — inverting the
+# Issue #236 bug into a "current project's review ignored" bug.
+#
+# Policy per state file encountered:
+#   * expired  (mtime > TTL)           → delete (GC) and continue scan
+#   * parse error / non-JSON           → skip (TTL will eventually collect)
+#   * legacy (no project_path)         → skip for Stop purposes (Issue #236
+#                                        safe-default; blocking would cause
+#                                        the same cross-session regression)
+#   * project_path matches current     → select it, stop scanning
+#   * project_path different           → skip (owning session cleans up; we
+#                                        are not authoritative over theirs)
+#
+# If no file matches the current project, Stop proceeds — there is no
+# in-flight review owned by this session to verify.
+STATE_FILE=""
+STATE=""
+for candidate in "${STATE_FILES[@]}"; do
+    mtime=$(stat -f %m "$candidate" 2>/dev/null || stat -c %Y "$candidate" 2>/dev/null || echo 0)
+    if [ $((NOW - mtime)) -gt $STATE_MAX_AGE ]; then
+        rm -f "$candidate"
+        continue
+    fi
+    candidate_state=$(cat "$candidate" 2>/dev/null || echo "")
+    if [ -z "$candidate_state" ] || ! echo "$candidate_state" | jq -e . >/dev/null 2>&1; then
+        continue
+    fi
+    candidate_project=$(echo "$candidate_state" | jq -r '.project_path // ""' 2>/dev/null || echo "")
+    if [ -z "$candidate_project" ]; then
+        # Legacy pre-#236 state: skip to avoid cross-session false-block.
+        continue
+    fi
+    if [ "$candidate_project" = "$CURRENT_PROJECT" ]; then
+        STATE_FILE="$candidate"
+        STATE="$candidate_state"
+        break
+    fi
+done
 
-# Validate STATE is parseable JSON before field extraction. A corrupt / empty
-# / truncated state file would otherwise produce an empty STATE_PROJECT via
-# the `//` fallback, which the legacy-state branch below would silently
-# interpret as "no binding" and skip — masking a genuine in-progress review.
-# On indeterminate data we skip (TTL-based GC removes the file eventually)
-# rather than block, because raising a hard error on a race-induced truncated
-# state would create a different false-block pattern.
-if ! echo "$STATE" | jq -e . >/dev/null 2>&1; then
+if [ -z "$STATE_FILE" ]; then
     exit 0
 fi
 
 # Extract all state fields in a single jq call — includes project_path for
-# the Issue #236 cross-project binding check alongside the workflow fields.
-read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE BOT_FEEDBACK_READ FINAL_CRITICAL FINAL_IMPORTANT < <(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.bot_feedback_read // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv')
-
-# Project binding check (Issue #236): skip state files that belong to a
-# different project. Without this, a stale state from session A (working on
-# project /foo) would block Stop in session B (working on project /bar). We
-# do NOT delete mismatched states here — the owning session may still be
-# active and will clean up on its own; TTL-based GC above handles truly
-# abandoned ones. `pwd -P` resolves symlinks so a checkout accessed via a
-# symlinked path still matches the canonical path recorded at init time.
-CURRENT_PROJECT="$(pwd -P 2>/dev/null || pwd)"
-if [ -n "$STATE_PROJECT" ] && [ "$STATE_PROJECT" != "$CURRENT_PROJECT" ]; then
-    # State belongs to another project — not our concern, let Stop proceed.
+# parity with the scan step. IFS=$'\t' ensures we split only on the @tsv
+# separator; default IFS would also split on spaces, corrupting paths like
+# "/Users/John Doe/...". On jq failure we skip rather than continue with
+# indeterminate fields (matches the "skip on parse trouble" policy above).
+if ! STATE_FIELDS=$(echo "$STATE" | jq -r '[(.project_path // ""), (.security_done // false | tostring), (.fixer_done // false | tostring), (.rereview_done // false | tostring), (.bot_feedback_read // false | tostring), (.final_critical // -1 | tostring), (.final_important // -1 | tostring)] | @tsv' 2>/dev/null); then
     exit 0
 fi
-# Legacy state files (pre-#236) genuinely lack a project_path field. Since we
-# validated JSON above, an empty STATE_PROJECT at this point reflects the
-# real schema rather than a parse failure. Treat legacy state as safe to
-# ignore for Stop purposes — blocking on it causes the exact Issue #236
-# regression. The TTL cleanup above removes legacy files eventually.
-if [ -z "$STATE_PROJECT" ]; then
-    exit 0
-fi
+IFS=$'\t' read -r STATE_PROJECT SECURITY_DONE FIXER_DONE REREVIEW_DONE BOT_FEEDBACK_READ FINAL_CRITICAL FINAL_IMPORTANT <<< "$STATE_FIELDS"
 
 # Load transcript once for all checks (avoid repeated file reads)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")

--- a/plugins/code/tests/check-code-review.bats
+++ b/plugins/code/tests/check-code-review.bats
@@ -2,8 +2,16 @@
 # Tests for check-pr-review-gate.sh (flag-based PR creation gate)
 
 setup() {
-    # Create temporary test directory
-    TEST_DIR=$(mktemp -d)
+    # Create temporary test directory. Fail loudly if mktemp is denied
+    # (e.g. by a sandbox policy) — otherwise `cd ""` silently stays in the
+    # caller's cwd and subsequent `git init`/`git add`/`git commit` would
+    # operate on the real checkout. See Issue #239.
+    TEST_DIR=$(mktemp -d 2>/dev/null) || { skip "mktemp -d failed (sandbox or quota?)"; }
+    [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] || { skip "mktemp -d produced invalid path: [$TEST_DIR]"; }
+    case "$TEST_DIR" in
+        /private/var/folders/*|/var/folders/*|/tmp/*|/private/tmp/*) ;;
+        *) skip "TEST_DIR not under an expected temp prefix: $TEST_DIR" ;;
+    esac
     cd "$TEST_DIR"
 
     # Initialize git repo
@@ -33,10 +41,17 @@ teardown() {
         rm -f "$REVIEW_FLAG"
     fi
 
-    # Clean up test directory
+    # Clean up test directory. Only rm -rf when TEST_DIR is under a
+    # recognised temp prefix — prevents a regression from turning teardown
+    # into a repo-nuke (Issue #239).
     if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
         cd /
-        rm -rf "$TEST_DIR"
+        case "$TEST_DIR" in
+            /private/var/folders/*|/var/folders/*|/tmp/*|/private/tmp/*)
+                rm -rf "$TEST_DIR" ;;
+            *)
+                echo "teardown: refusing to rm -rf unsafe TEST_DIR: $TEST_DIR" >&2 ;;
+        esac
     fi
 }
 
@@ -137,13 +152,29 @@ teardown() {
 # ============================================================================
 
 @test "approval flag is per-repository" {
-    # Create two repos
-    REPO1=$(mktemp -d)
-    REPO2=$(mktemp -d)
+    # Create two repos. Fail the test loudly if mktemp is denied — `cd ""`
+    # would otherwise leave us in the real checkout for the subsequent
+    # git init / commit, and cleanup `rm -rf ""` would error rather than
+    # remove the real repo, but the intermediate `git init` pollution would
+    # still be real. See Issue #239.
+    REPO1=$(mktemp -d 2>/dev/null) || { skip "mktemp -d failed (sandbox?)"; }
+    REPO2=$(mktemp -d 2>/dev/null) || { skip "mktemp -d failed (sandbox?)"; }
+    for _r in "$REPO1" "$REPO2"; do
+        [ -n "$_r" ] && [ -d "$_r" ] || { skip "mktemp produced invalid path: [$_r]"; }
+        case "$_r" in
+            /private/var/folders/*|/var/folders/*|/tmp/*|/private/tmp/*) ;;
+            *) skip "mktemp path outside expected temp prefix: $_r" ;;
+        esac
+    done
 
     cleanup_repos() {
         cd /
-        rm -rf "$REPO1" "$REPO2" 2>/dev/null || true
+        for _r in "$REPO1" "$REPO2"; do
+            case "$_r" in
+                /private/var/folders/*|/var/folders/*|/tmp/*|/private/tmp/*)
+                    rm -rf "$_r" 2>/dev/null || true ;;
+            esac
+        done
         rm -f /tmp/claude/review-approved-* 2>/dev/null || true
     }
     trap cleanup_repos EXIT

--- a/plugins/code/tests/pr-review-state-session-binding.bats
+++ b/plugins/code/tests/pr-review-state-session-binding.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# Tests for Issue #236: pr-review-team state files must be bound to the
+# originating project so stale state from unrelated sessions/projects does
+# not block Stop hook in a different session.
+
+setup() {
+    # Canonicalize so tests match `pwd -P` output used in production scripts
+    # (macOS resolves /var/folders → /private/var/folders on mktemp dirs).
+    export TEST_DIR=$(cd "$(mktemp -d)" && pwd -P)
+    export STATE_DIR="${TEST_DIR}/claude"
+    mkdir -p "$STATE_DIR"
+
+    # Override /tmp/claude so we don't clobber real state files.
+    export TMPDIR_ORIG="${TMPDIR:-/tmp}"
+
+    # Resolve script paths relative to this test file.
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    export INIT_SCRIPT="${PLUGIN_ROOT}/scripts/pr-review-state.sh"
+    export VERIFY_SCRIPT="${PLUGIN_ROOT}/skills/pr-review-team/scripts/verify-workflow.sh"
+
+    # Verify scripts exist before running any test.
+    [ -x "$INIT_SCRIPT" ] || skip "init script not executable: $INIT_SCRIPT"
+    [ -x "$VERIFY_SCRIPT" ] || skip "verify script not executable: $VERIFY_SCRIPT"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+    # Clean any test state files we may have created under the real
+    # /tmp/claude to prevent cross-test pollution.
+    rm -f /tmp/claude/pr-review-9999.state /tmp/claude/pr-review-9999.done
+}
+
+# Helper: invoke verify-workflow.sh with a minimal hook input JSON.
+run_verify() {
+    local transcript_path="${1:-}"
+    printf '{"stop_hook_active":false,"transcript_path":"%s"}' "$transcript_path" \
+        | "$VERIFY_SCRIPT"
+}
+
+@test "init records current project_path in state JSON" {
+    cd "$TEST_DIR"
+    run "$INIT_SCRIPT" init 9999
+    [ "$status" -eq 0 ]
+
+    # State file lives under the hard-coded /tmp/claude path.
+    [ -f /tmp/claude/pr-review-9999.state ]
+
+    # project_path should equal the cwd where init was invoked.
+    project=$(jq -r '.project_path' /tmp/claude/pr-review-9999.state)
+    [ "$project" = "$TEST_DIR" ]
+}
+
+@test "init records session_id when CLAUDE_SESSION_ID env is set" {
+    cd "$TEST_DIR"
+    CLAUDE_SESSION_ID="test-session-abc" run "$INIT_SCRIPT" init 9999
+    [ "$status" -eq 0 ]
+
+    session=$(jq -r '.session_id' /tmp/claude/pr-review-9999.state)
+    [ "$session" = "test-session-abc" ]
+}
+
+@test "verify-workflow skips state from a different project" {
+    # Create state as if it came from another project.
+    mkdir -p /tmp/claude
+    jq -n --arg pp "/some/other/project/path" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:false, security_done:false, fixer_done:false,
+          rereview_done:false, iterations:0, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    cd "$TEST_DIR"
+    run run_verify ""
+    # Exit 0 and no block output — the state belongs to another project.
+    [ "$status" -eq 0 ]
+    # Output must NOT contain a block decision.
+    [[ "$output" != *'"decision":"block"'* ]]
+}
+
+@test "verify-workflow skips legacy state without project_path" {
+    # Simulate a pre-#236 state file (no project_path field).
+    mkdir -p /tmp/claude
+    printf '{"pr":"9999","phase":"started","reviewers_done":false,"security_done":false,"fixer_done":false,"rereview_done":false,"iterations":0,"final_critical":-1,"final_important":-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    cd "$TEST_DIR"
+    run run_verify ""
+    [ "$status" -eq 0 ]
+    # Legacy state is safely ignored for Stop purposes (Issue #236).
+    [[ "$output" != *'"decision":"block"'* ]]
+}
+
+@test "verify-workflow proceeds for matching project_path" {
+    # Create a state file belonging to the current project.
+    cd "$TEST_DIR"
+    mkdir -p /tmp/claude
+    jq -n --arg pp "$TEST_DIR" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:false, security_done:false, fixer_done:false,
+          rereview_done:false, iterations:0, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    # Without security_done=true and no transcript evidence, the hook should
+    # emit a block. We only confirm the hook engaged (i.e., did not silently
+    # skip) — the exact content depends on transcript heuristics.
+    run run_verify ""
+    [ "$status" -eq 0 ]
+    # For a matching-project state in "started" phase, the hook should
+    # evaluate the workflow checks and produce a block payload.
+    [[ "$output" == *"decision"*"block"* ]]
+}

--- a/plugins/code/tests/pr-review-state-session-binding.bats
+++ b/plugins/code/tests/pr-review-state-session-binding.bats
@@ -141,7 +141,8 @@ run_verify() {
     jq -n --arg pp "$TEST_DIR" \
         '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
           reviewers_done:false, security_done:false, fixer_done:false,
-          rereview_done:false, iterations:0, final_critical:-1, final_important:-1}' \
+          rereview_done:false, bot_feedback_read:false,
+          iterations:0, final_critical:-1, final_important:-1}' \
         > /tmp/claude/pr-review-9999.state
 
     # Without security_done=true and no transcript evidence, the hook should
@@ -152,4 +153,92 @@ run_verify() {
     # For a matching-project state in "started" phase, the hook should
     # evaluate the workflow checks and produce a block payload.
     [[ "$output" == *"decision"*"block"* ]]
+}
+
+@test "init includes bot_feedback_read field (default false)" {
+    cd "$TEST_DIR"
+    run "$INIT_SCRIPT" init 9999
+    [ "$status" -eq 0 ]
+    flag=$(jq -r '.bot_feedback_read' /tmp/claude/pr-review-9999.state)
+    [ "$flag" = "false" ]
+}
+
+@test "verify-workflow blocks when rereview_done=true but transcript shows only 1 reviewer launch" {
+    cd "$TEST_DIR"
+    mkdir -p /tmp/claude
+    jq -n --arg pp "$TEST_DIR" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:true, security_done:true, fixer_done:true,
+          rereview_done:true, bot_feedback_read:true,
+          iterations:1, final_critical:0, final_important:0}' \
+        > /tmp/claude/pr-review-9999.state
+
+    # Transcript mentions pr-review-toolkit:code-reviewer only once.
+    local t="${TEST_DIR}/transcript1.txt"
+    printf 'some content\n"subagent_type": "pr-review-toolkit:code-reviewer"\nmore content\n' > "$t"
+
+    run run_verify "$t"
+    [ "$status" -eq 0 ]
+    # Should block because only 1 launch (needs ≥2 for re-review).
+    [[ "$output" == *"decision"*"block"* ]]
+    [[ "$output" == *"rereview_done=true but transcript shows only"* ]]
+}
+
+@test "verify-workflow accepts rereview when transcript shows 2+ reviewer launches" {
+    cd "$TEST_DIR"
+    mkdir -p /tmp/claude
+    jq -n --arg pp "$TEST_DIR" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:true, security_done:true, fixer_done:true,
+          rereview_done:true, bot_feedback_read:true,
+          iterations:2, final_critical:0, final_important:0}' \
+        > /tmp/claude/pr-review-9999.state
+
+    local t="${TEST_DIR}/transcript2.txt"
+    printf '%s\n%s\n' \
+        '"subagent_type": "pr-review-toolkit:code-reviewer"' \
+        '"subagent_type": "pr-review-toolkit:code-reviewer"' \
+        > "$t"
+
+    run run_verify "$t"
+    [ "$status" -eq 0 ]
+    # With both launches + all state complete, should NOT block on Check 3b.
+    [[ "$output" != *"rereview_done=true but transcript shows only"* ]]
+}
+
+@test "verify-workflow blocks when bot_feedback_read=false and no transcript evidence" {
+    cd "$TEST_DIR"
+    mkdir -p /tmp/claude
+    jq -n --arg pp "$TEST_DIR" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:true, security_done:true, fixer_done:true,
+          rereview_done:false, bot_feedback_read:false,
+          iterations:1, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    local t="${TEST_DIR}/transcript-no-bot.txt"
+    echo "random content without bot checks" > "$t"
+
+    run run_verify "$t"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Bot feedback"*"was not read"* ]]
+}
+
+@test "verify-workflow accepts bot feedback evidence from transcript" {
+    cd "$TEST_DIR"
+    mkdir -p /tmp/claude
+    jq -n --arg pp "$TEST_DIR" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:true, security_done:true, fixer_done:true,
+          rereview_done:false, bot_feedback_read:false,
+          iterations:1, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    local t="${TEST_DIR}/transcript-with-bot.txt"
+    echo "gh pr view 9999 --json reviews,comments" > "$t"
+
+    run run_verify "$t"
+    [ "$status" -eq 0 ]
+    # Bot feedback check should NOT contribute to block (transcript has evidence).
+    [[ "$output" != *"Bot feedback"* ]]
 }

--- a/plugins/code/tests/pr-review-state-session-binding.bats
+++ b/plugins/code/tests/pr-review-state-session-binding.bats
@@ -10,8 +10,19 @@ setup() {
     export STATE_DIR="${TEST_DIR}/claude"
     mkdir -p "$STATE_DIR"
 
-    # Override /tmp/claude so we don't clobber real state files.
-    export TMPDIR_ORIG="${TMPDIR:-/tmp}"
+    # Isolate from any existing /tmp/claude/pr-review-*.state files: the
+    # production script picks STATE_FILES[0] (glob-sorted first), so a
+    # real-session state present at test time would be selected instead of
+    # ours. Move them to a per-test backup and restore in teardown.
+    mkdir -p /tmp/claude
+    export TEST_STATE_BACKUP="${TEST_DIR}/state-backup"
+    mkdir -p "$TEST_STATE_BACKUP"
+    shopt -s nullglob
+    local existing=(/tmp/claude/pr-review-*.state /tmp/claude/pr-review-*.done)
+    shopt -u nullglob
+    if [ "${#existing[@]}" -gt 0 ]; then
+        mv "${existing[@]}" "$TEST_STATE_BACKUP/" 2>/dev/null || true
+    fi
 
     # Resolve script paths relative to this test file.
     PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
@@ -24,10 +35,19 @@ setup() {
 }
 
 teardown() {
-    rm -rf "$TEST_DIR"
-    # Clean any test state files we may have created under the real
-    # /tmp/claude to prevent cross-test pollution.
+    # Remove test-created state files before restoring backups.
     rm -f /tmp/claude/pr-review-9999.state /tmp/claude/pr-review-9999.done
+
+    # Restore any pre-existing state files that setup moved aside.
+    if [ -d "$TEST_STATE_BACKUP" ]; then
+        shopt -s nullglob
+        local restored=("$TEST_STATE_BACKUP"/pr-review-*.state "$TEST_STATE_BACKUP"/pr-review-*.done)
+        shopt -u nullglob
+        if [ "${#restored[@]}" -gt 0 ]; then
+            mv "${restored[@]}" /tmp/claude/ 2>/dev/null || true
+        fi
+    fi
+    rm -rf "$TEST_DIR"
 }
 
 # Helper: invoke verify-workflow.sh with a minimal hook input JSON.

--- a/plugins/code/tests/pr-review-state-session-binding.bats
+++ b/plugins/code/tests/pr-review-state-session-binding.bats
@@ -51,7 +51,8 @@ setup() {
 
 teardown() {
     # Remove test-created state files before restoring backups.
-    rm -f /tmp/claude/pr-review-9999.state /tmp/claude/pr-review-9999.done
+    rm -f /tmp/claude/pr-review-9999.state /tmp/claude/pr-review-9999.done \
+          /tmp/claude/pr-review-8888.state /tmp/claude/pr-review-8888.done
 
     # Restore any pre-existing state files that setup moved aside.
     if [ -d "$TEST_STATE_BACKUP" ]; then
@@ -222,6 +223,60 @@ run_verify() {
     run run_verify "$t"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Bot feedback"*"was not read"* ]]
+}
+
+@test "verify-workflow selects current-project state when mixed with other-project state" {
+    # Regression: earlier implementation used STATE_FILES[0] (glob order),
+    # so a state file sorting before the current-project one would cause
+    # the verifier to early-exit on a project mismatch, silently skipping
+    # the active current-project review. The fix iterates all files.
+    mkdir -p /tmp/claude
+    # 8888 glob-sorts before 9999; simulate an unrelated other-project state
+    # in the "first slot" to prove the scan picks 9999 for the current cwd.
+    jq -n --arg pp "/some/other/project" \
+        '{pr:"8888", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:false, security_done:false, fixer_done:false,
+          rereview_done:false, bot_feedback_read:false,
+          iterations:0, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-8888.state
+
+    cd "$TEST_DIR"
+    jq -n --arg pp "$TEST_DIR" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:false, security_done:false, fixer_done:false,
+          rereview_done:false, bot_feedback_read:false,
+          iterations:0, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    run run_verify ""
+    [ "$status" -eq 0 ]
+    # Current-project state must be picked up and produce a block payload
+    # (security not done + no transcript evidence). If the scan had skipped
+    # 9999 because 8888 came first, no block would fire.
+    [[ "$output" == *"decision"*"block"* ]]
+}
+
+@test "verify-workflow handles project_path containing spaces" {
+    # Regression: with default IFS, `read -r` splits @tsv output on spaces
+    # too, so a project_path like "/Users/John Doe/..." was shifting the
+    # remaining fields. IFS=$'\t' fix keeps all fields intact.
+    local space_dir="${TEST_DIR}/with space"
+    mkdir -p "$space_dir"
+    space_dir=$(cd "$space_dir" && pwd -P)
+
+    mkdir -p /tmp/claude
+    jq -n --arg pp "$space_dir" \
+        '{pr:"9999", session_id:"", project_path:$pp, phase:"started",
+          reviewers_done:false, security_done:false, fixer_done:false,
+          rereview_done:false, bot_feedback_read:false,
+          iterations:0, final_critical:-1, final_important:-1}' \
+        > /tmp/claude/pr-review-9999.state
+
+    cd "$space_dir"
+    run run_verify ""
+    [ "$status" -eq 0 ]
+    # Matching-project state must engage the workflow checks and emit block.
+    [[ "$output" == *"decision"*"block"* ]]
 }
 
 @test "verify-workflow accepts bot feedback evidence from transcript" {

--- a/plugins/code/tests/pr-review-state-session-binding.bats
+++ b/plugins/code/tests/pr-review-state-session-binding.bats
@@ -4,9 +4,24 @@
 # not block Stop hook in a different session.
 
 setup() {
+    # Create a scratch directory. Fail loudly if mktemp is denied (e.g. by a
+    # sandbox policy) — otherwise `$(cd "" && pwd -P)` silently evaluates to
+    # the current working directory, which for this repo would make the
+    # teardown `rm -rf "$TEST_DIR"` obliterate the checkout. See Issue #239.
+    local _tmp
+    _tmp=$(mktemp -d 2>/dev/null) || { skip "mktemp -d failed (sandbox or quota?)"; }
+    [ -n "$_tmp" ] && [ -d "$_tmp" ] || { skip "mktemp -d produced invalid path: [$_tmp]"; }
     # Canonicalize so tests match `pwd -P` output used in production scripts
     # (macOS resolves /var/folders → /private/var/folders on mktemp dirs).
-    export TEST_DIR=$(cd "$(mktemp -d)" && pwd -P)
+    export TEST_DIR
+    TEST_DIR=$(cd "$_tmp" && pwd -P)
+    # Defensive: refuse to proceed unless TEST_DIR points at a known-safe
+    # temp prefix. This is a belt-and-braces guard against any future
+    # regression that might yield a non-temp path.
+    case "$TEST_DIR" in
+        /private/var/folders/*|/var/folders/*|/tmp/*|/private/tmp/*) ;;
+        *) skip "TEST_DIR not under an expected temp prefix: $TEST_DIR" ;;
+    esac
     export STATE_DIR="${TEST_DIR}/claude"
     mkdir -p "$STATE_DIR"
 
@@ -47,7 +62,17 @@ teardown() {
             mv "${restored[@]}" /tmp/claude/ 2>/dev/null || true
         fi
     fi
-    rm -rf "$TEST_DIR"
+    # Belt-and-braces: only rm -rf when TEST_DIR is populated AND under a
+    # recognised temp prefix. Prevents a regression in setup() from turning
+    # teardown into a repo-nuke (Issue #239).
+    if [ -n "${TEST_DIR:-}" ] && [ -d "$TEST_DIR" ]; then
+        case "$TEST_DIR" in
+            /private/var/folders/*|/var/folders/*|/tmp/*|/private/tmp/*)
+                rm -rf "$TEST_DIR" ;;
+            *)
+                echo "teardown: refusing to rm -rf unsafe TEST_DIR: $TEST_DIR" >&2 ;;
+        esac
+    fi
 }
 
 # Helper: invoke verify-workflow.sh with a minimal hook input JSON.


### PR DESCRIPTION
## 概要

`/tmp/claude/pr-review-*.state` に session / project binding が無いため、
session A で中断された state が別プロジェクトの session B の Stop hook を
誤発火させる bug (Issue #236) を修正する。

**Scope 明記（Copilot レビュー対応）**: #236 本体の project_path binding に加え、
iteration 内で以下の enforcement を追加する（Stop hook が新たに block する条件）:

- `rereview_done=true` は transcript 上に `pr-review-toolkit:code-reviewer`
  の launch が 2 回以上あることが必要（self-declaration 禁止）
- `bot_feedback_read=true` は state flag 明示 or transcript に `gh pr view
  --json reviews,comments` 等の証跡が必要（bot 指摘の読み飛ばし防止）

これらは #236 の回帰として混入した convergence 判定の抜け穴への対応。
既存 workflow ユーザーは SKILL.md Step 5 の 5-6 に追加された手順に従えば満たせる。

## 症状 (empirical)

"Security checklist was not read" で Stop が繰り返し block。該当 PR はその
session で一切触っていない別リポジトリのもの。本日のセッション内でも 2 回
踏んだ（`pr-review-36.state`、`pr-review-124.state`）。

## 修正内容

### 1. `plugins/code/scripts/pr-review-state.sh` — init

state JSON に 3 フィールド追加:

- `project_path`: `pwd -P`（symlink 解決済み）
- `session_id`: `$CLAUDE_SESSION_ID` 環境変数（未設定なら空、supplementary）
- `bot_feedback_read`: default false（enforcement 用フラグ）

jq 利用可否で分岐（fallback は printf）。

### 2. `plugins/code/skills/pr-review-team/scripts/verify-workflow.sh`

- `project_path` で state を正しく選択（全 state file を scan してマッチする
  ものを選ぶ — 旧実装の `STATE_FILES[0]` 決め打ちは別 project の state が先頭
  に来ると current project の review を silent に skip する bug を抱えていた、
  claude-review #1 指摘）
- IFS=$'\t' + jq 失敗時 skip で field split を堅牢化（Copilot #1 指摘）
- Check 3b: `rereview_done=true` の transcript 証跡検証
- Check 3c: `bot_feedback_read` 要求

state 選択ロジック:

| state.project_path | pwd -P 一致？ | 動作 |
|---|:-:|---|
| 値あり | 一致 | 選択、workflow check 実行 |
| 値あり | 不一致 | skip（次の state file を見る） |
| 空 / 欠如 (legacy) | — | skip（safe default） |
| 期限切れ (>1h) | — | GC 削除して skip |
| JSON parse 不能 | — | skip（TTL で GC） |
| どれもマッチしない | — | exit 0（このセッションに review 無し） |

### 3. `plugins/code/skills/pr-review-team/SKILL.md`

- Step 5 に bot feedback 読込ステップ (5) を追加
- Step 6 に `rereview_done true` の set コマンドを追加（claude-review #3 指摘）
- 🔴 VIOLATION ブロックで self-declared convergence 禁止を明記

### 4. `plugins/code/tests/pr-review-state-session-binding.bats` (新規)

12 シナリオ bats test、全て pass:

1. init が `project_path` を JSON に記録
2. init が `CLAUDE_SESSION_ID` env を拾う
3. verify が別プロジェクトの state を skip
4. verify が legacy state を skip
5. verify が matching project で workflow check を実行
6. init が `bot_feedback_read` を default false で記録
7. `rereview_done=true` + reviewer launch 1回 → block
8. `rereview_done=true` + reviewer launch 2回 → pass
9. `bot_feedback_read=false` + transcript 証跡なし → block
10. mixed state files（別 project + current project）で current を選択（regression）
11. project_path にスペース含む場合の field split 堅牢性（regression）
12. transcript に `gh pr view` 証跡あり → bot feedback check 合格

## 設計判断

- **Path canonicalization**: macOS の `/var/folders` → `/private/var/folders`
  symlink で誤 mismatch する問題を `pwd -P` で解消
- **jq call 統合**: Stop hook は session 終了毎に fire するため hot path、
  2 jq call を 1 つに merge（~10ms 削減）
- **Legacy safe-skip**: 古い state (project_path 欠如) を block せず skip。
  TTL 1h GC があるため短命で消える、一方で誤 block の user 被害の方が大きい
- **State 全走査**: グロブ先頭 1 件だけ見る実装は glob 順（shell 依存）に
  依存して別 project の state が先頭に来ると current の review を取り逃がす。
  全件走査 + 現 project マッチで選ぶ方が correctness 上正しい
- **IFS=$'\\t'**: jq `@tsv` はタブのみエスケープ、スペースは素通し。IFS
  default (space/tab/newline) だと path にスペースを含む project が壊れる
- **Session_id は未使用**: 現在のロジックは project_path 優先。session_id は
  将来の debug / cross-session correlation 用途で記録のみ

## 関連

- Issue #236 (本日 user 起票) — 本 PR で close
- Issue #222 (bats 一般化) — 本 PR は session binding 用 test のみ、infra 全体改善は別 Issue で
- Issue #239 (bats teardown 自爆) — 62df7e8 で根治済み

## Test plan

- [x] bats `pr-review-state-session-binding.bats`: 12/12 pass
- [x] 既存 bats test (`check-code-review.bats`) 無影響
- [x] CI claude-review 通過

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)