### PR TITLE
fix(code): remove stale dangerouslyDisableSandbox guidance from pr-review-team

### DIFF
--- a/plugins/code/scripts/wait-ci-checks.sh
+++ b/plugins/code/scripts/wait-ci-checks.sh
@@ -12,8 +12,8 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     echo "=== CI Check Attempt $attempt/$MAX_ATTEMPTS ==="
 
     CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null) || {
-        echo "STATUS: ERROR (gh command failed — possible TLS/sandbox issue)"
-        echo "ACTION: Use dangerouslyDisableSandbox: true and retry"
+        echo "STATUS: ERROR (gh command failed)"
+        echo "ACTION: Check network, gh auth status, and PR number — sandbox bypass is not the fix"
         exit 0
     }
 

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -43,7 +43,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR番号>
 - Test command: detect from `package.json`, `Makefile`, `pytest.ini`, etc.
 - Project rules: read project's CLAUDE.md if present
 
-**Note**: `gh` commands may require `dangerouslyDisableSandbox: true` for TLS issues.
+**Note**: `gh` commands rely on `sandbox.network.allowedDomains` (github.com, api.github.com) in `~/.claude/settings.json` to run inside the sandbox without prompts. Do NOT pass `dangerouslyDisableSandbox: true` defensively — see `code:autopilot` SKILL §Sandbox bypass policy for why the flag breaks auto mode.
 
 ## Step 2: Parallel Review (Subagents)
 
@@ -79,7 +79,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh set <PR番号> phase revie
 
 ## Step 3: CI Check
 
-Run the CI wait script (requires `dangerouslyDisableSandbox: true`):
+Run the CI wait script:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh <PR番号>
@@ -89,7 +89,7 @@ Parse the STATUS line from output:
 - **PASS**: All checks passed
 - **FAIL**: Get failure details with `gh run view <run-id> --log-failed`
 - **TIMEOUT**: Continue review, note "CI: PENDING (timed out)" in report
-- **ERROR**: Retry with `dangerouslyDisableSandbox: true`
+- **ERROR**: Report the failure and stop — network / auth / PR-number issues won't be solved by sandbox bypass. See `code:autopilot` SKILL §Sandbox bypass policy.
 
 Also collect review comments:
 ```bash


### PR DESCRIPTION
## 概要

autopilot の post-pr-review phase で pr-review-team が走ると、`gh pr diff` / `gh pr checks` 等で sandbox bypass の blocking prompt が出て pipeline が止まる問題を修正する。

## 真因

pr-review-team SKILL.md L46 / L82 / L92 および `wait-ci-checks.sh` L15-16 が、現環境では不要な `dangerouslyDisableSandbox: true` を defensive に指示していた。これが autopilot SKILL.md L141 の「pr-review-team では flag を渡さない」policy と衝突し、blocking user prompt を引き起こしていた。

## 現環境での不要性（検証済み）

`~/.claude/settings.json` に以下が既に設定済み:

- `sandbox.network.allowedDomains`: `github.com`, `api.github.com`, `*.github.com`, `raw.githubusercontent.com`
- `sandbox.autoAllowBashIfSandboxed: true`
- `sandbox.enableWeakerNetworkIsolation: true`

実地検証済み (empirical, 本 session 内で直前に確認):

| コマンド | `dangerouslyDisableSandbox` | 結果 |
|---|---|---|
| `gh pr diff 238 --name-only` | false (sandbox on) | ✅ 成功、prompt なし |
| `gh pr checks 238` | false (sandbox on) | ✅ 成功、prompt なし |
| `gh pr view 238 --json state` | false (sandbox on) | ✅ 成功、prompt なし |

## 変更内容

### `plugins/code/skills/pr-review-team/SKILL.md`

| 場所 | Before | After |
|---|---|---|
| L46 | `**Note**: gh commands may require dangerouslyDisableSandbox: true for TLS issues.` | `sandbox.network.allowedDomains` に依存する旨と `Do NOT pass dangerouslyDisableSandbox: true defensively` の explicit prohibition。autopilot policy への cross-reference |
| L82 | `Run the CI wait script (requires dangerouslyDisableSandbox: true):` | `Run the CI wait script:` |
| L92 | `ERROR: Retry with dangerouslyDisableSandbox: true` | `ERROR: Report the failure and stop — network / auth / PR-number issues won't be solved by sandbox bypass.` |

### `plugins/code/scripts/wait-ci-checks.sh`

| 行 | Before | After |
|---|---|---|
| L15 | `STATUS: ERROR (gh command failed — possible TLS/sandbox issue)` | `STATUS: ERROR (gh command failed)` |
| L16 | `ACTION: Use dangerouslyDisableSandbox: true and retry` | `ACTION: Check network, gh auth status, and PR number — sandbox bypass is not the fix` |

## 調査経緯

1. **公式 docs (Claude Code sandboxing.md / settings.md / sub-agents.md / hooks.md)** で `allowedDomains` の挙動、`dangerouslyDisableSandbox` と permission flow の関係、subagent 継承を確認
2. **CodeX クロス検証** で scope リスク（他 domain への接続、MITM proxy 要件）を洗い出し — pr-review-team が使う `pr diff` / `pr checks` / `pr view` はすべて `api.github.com` 範囲内で scope 内安全と判明
3. **empirical 検証** で現環境での動作を確認

## 非スコープ

- `plugins/code/skills/autopilot/SKILL.md` L135-143 の「auto mode では bypass を pre-approve 不能」主張は公式 docs (PreToolUse hook の `permissionDecision: "allow"` で skip 可) と矛盾する可能性があるが、本 PR では触らない（別 Issue 案件）
- pr-review-toolkit 外部 plugin 側の agent 定義は変更しない
- sandbox 設定自体の変更不要

## Test plan

- [x] `grep -r dangerouslyDisableSandbox plugins/code/skills/pr-review-team/` → L46 の explicit prohibition 以外 0 件
- [x] `grep dangerouslyDisableSandbox plugins/code/scripts/wait-ci-checks.sh` → 0 件
- [x] `bats plugins/code/tests/` 全件実行 → 本 PR による regression なし（pre-existing failure 2 件は別 skill / base 既存）
- [ ] 本 PR merge 後、`/code:autopilot` を走らせて post-pr-review phase で blocking prompt が出ないことを確認（本 PR 自身の post-pr-review phase で即検証）

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)