### PR TITLE
fix(code): propagate sandbox rule to pr-review-team subagents

### DIFF
--- a/plugins/code/skills/dev-cycle/references/main-agent-guide.md
+++ b/plugins/code/skills/dev-cycle/references/main-agent-guide.md
@@ -15,6 +15,7 @@
 1. Spawn agents in parallel via Agent tool (NOT Task tool):
    `Agent(subagent_type: "general-purpose", mode: "acceptEdits", model: "<choose per task>", prompt: "...")`
    **MANDATORY**: Always specify an explicit `model` parameter (`haiku` for lightweight, `sonnet` for standard, `opus` for complex reasoning). Never omit `model` (default `inherit` may fail in parallel spawning).
+   **MANDATORY** (Issue #245): Include in every agent prompt the sandbox tooling note defined in `${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/SKILL.md` Step 2 (the `Tooling note: Do NOT set dangerouslyDisableSandbox: true ...` block). Agent-spawned subagents do not see the orchestrator's SKILL body; omitting the note causes defensive sandbox-bypass approval prompts to the user.
 2. Wait for all agents to report completion (each Agent call blocks until the subagent returns)
 3. No shutdown procedure needed — subagents complete automatically
 4. **Commit per-agent individually** (lead performs commits, not agents)

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -64,10 +64,10 @@ breaks the review flow.
 
 Launch in parallel (one message, 4 Agent tool calls):
 
-1. `Agent(subagent_type: "pr-review-toolkit:code-reviewer", model: "sonnet", prompt: "<criteria path> + <tooling note above> + <task>")`
-2. `Agent(subagent_type: "pr-review-toolkit:silent-failure-hunter", model: "sonnet", prompt: "<criteria path> + <tooling note above> + <task>")`
-3. `Agent(subagent_type: "pr-review-toolkit:pr-test-analyzer", model: "sonnet", prompt: "<criteria path> + <tooling note above> + <task>")`
-4. `Agent(subagent_type: "pr-review-toolkit:comment-analyzer", model: "haiku", prompt: "<criteria path> + <tooling note above> + <task>")`
+1. `Agent(subagent_type: "pr-review-toolkit:code-reviewer", model: "sonnet", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
+2. `Agent(subagent_type: "pr-review-toolkit:silent-failure-hunter", model: "sonnet", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
+3. `Agent(subagent_type: "pr-review-toolkit:pr-test-analyzer", model: "sonnet", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
+4. `Agent(subagent_type: "pr-review-toolkit:comment-analyzer", model: "haiku", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
 
 Results return automatically. No shutdown procedure needed.
 

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -50,12 +50,24 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR番号>
 **MANDATORY**: Launch ALL 4 reviewers in a SINGLE message using parallel Agent tool calls.
 Do NOT use TeamCreate or Task tool. Use the Agent tool directly.
 
+🔴 **Subagent prompt requirement (Issue #245)** — Agent tool で spawn される subagent は orchestrator の SKILL 本文を見ない。以下のガード文をすべての subagent prompt に **必ず含める**（reviewers, fixer, re-reviewers 共通）:
+
+```
+Tooling note: Do NOT set dangerouslyDisableSandbox: true on any bash call.
+gh / git commands work inside the default sandbox (see ~/.claude/settings.json
+sandbox.network.allowedDomains). Setting the bypass flag forces a user
+approval prompt that auto mode intentionally refuses to auto-approve, which
+breaks the review flow.
+```
+
+省略すると subagent が `gh pr diff` 等で defensive に bypass を要求し、ユーザーに承認プロンプトが連発する。
+
 Launch in parallel (one message, 4 Agent tool calls):
 
-1. `Agent(subagent_type: "pr-review-toolkit:code-reviewer", model: "sonnet", prompt: "...")`
-2. `Agent(subagent_type: "pr-review-toolkit:silent-failure-hunter", model: "sonnet", prompt: "...")`
-3. `Agent(subagent_type: "pr-review-toolkit:pr-test-analyzer", model: "sonnet", prompt: "...")`
-4. `Agent(subagent_type: "pr-review-toolkit:comment-analyzer", model: "haiku", prompt: "...")`
+1. `Agent(subagent_type: "pr-review-toolkit:code-reviewer", model: "sonnet", prompt: "<criteria path> + <tooling note above> + <task>")`
+2. `Agent(subagent_type: "pr-review-toolkit:silent-failure-hunter", model: "sonnet", prompt: "<criteria path> + <tooling note above> + <task>")`
+3. `Agent(subagent_type: "pr-review-toolkit:pr-test-analyzer", model: "sonnet", prompt: "<criteria path> + <tooling note above> + <task>")`
+4. `Agent(subagent_type: "pr-review-toolkit:comment-analyzer", model: "haiku", prompt: "<criteria path> + <tooling note above> + <task>")`
 
 Results return automatically. No shutdown procedure needed.
 
@@ -159,13 +171,16 @@ MAX_ITERATIONS=3
 
 FOR iteration = 1 TO MAX_ITERATIONS:
   1. Spawn fixer subagent:
-     Agent(subagent_type: "general-purpose", model: "sonnet", prompt: "<all findings>")
-     Send ALL findings in a single prompt (Critical + Important + Security failures)
+     Agent(subagent_type: "general-purpose", model: "sonnet",
+           prompt: "<all findings> + <Step 2 tooling note on dangerouslyDisableSandbox>")
+     Send ALL findings in a single prompt (Critical + Important + Security failures).
+     The fixer also runs gh/git — propagate the same sandbox guard (Issue #245).
 
   2. Fixer applies fixes and runs tests
      IF tests fail after 2 retries → report to user, do NOT merge, BREAK
 
-  3. Re-review: Launch ALL 4 reviewers again (parallel Agent tool calls, same as Step 2)
+  3. Re-review: Launch ALL 4 reviewers again (parallel Agent tool calls, same as Step 2,
+     including the tooling note in each subagent prompt)
 
   4. Collect fresh counts: fresh_critical, fresh_important, fresh_security
 

--- a/plugins/code/skills/retrospective/SKILL.md
+++ b/plugins/code/skills/retrospective/SKILL.md
@@ -38,6 +38,8 @@ Spawn 2 agents using the Task tool (`subagent_type: "general-purpose"`, `model: 
 
 **MANDATORY**: Always specify an explicit `model` parameter. Choose the appropriate model based on task complexity (`haiku` for lightweight, `sonnet` for standard, `opus` for complex reasoning). Never omit `model` (default `inherit` may fail in parallel spawning).
 
+**MANDATORY** (Issue #245): Auditor and Researcher both invoke `git log` / `gh pr view` during analysis. Include in each agent prompt the sandbox tooling note defined in `${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/SKILL.md` Step 2 (the `Tooling note: Do NOT set dangerouslyDisableSandbox: true ...` block). Agent-spawned subagents do not see the orchestrator's SKILL body; omitting the note causes defensive sandbox-bypass approval prompts to the user.
+
 Auditor and Researcher are independent — no inter-agent communication needed.
 
 #### Agent 1: Auditor

--- a/plugins/code/skills/sprint-impl/SKILL.md
+++ b/plugins/code/skills/sprint-impl/SKILL.md
@@ -98,6 +98,7 @@ For parallel tasks:
 1. **TeamCreate** with descriptive team name
 2. **Spawn agents** in parallel via Task tool (`subagent_type: "general-purpose"`, `mode: "acceptEdits"`, `model: "<choose per task>"`)
    - **MANDATORY**: Always specify an explicit `model` parameter. Choose the appropriate model based on task complexity (`haiku` for lightweight, `sonnet` for standard, `opus` for complex reasoning). Never omit `model` (default `inherit` may fail in parallel spawning).
+   - **MANDATORY** (Issue #245): include in every agent prompt the sandbox tooling note defined in `${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/SKILL.md` Step 2 (the `Tooling note: Do NOT set dangerouslyDisableSandbox: true ...` block). Agent-spawned subagents do not see the orchestrator's SKILL body; omitting the note causes defensive sandbox-bypass approval prompts to the user.
    - If Active Learnings were loaded in Phase 1, append to each agent's task description under `## Project Learnings`
    - Keep injected learnings concise: include only the "Action" field from each active learning
    - Example:


### PR DESCRIPTION
## Summary

- `skills/pr-review-team/SKILL.md` Step 2 に subagent prompt template 要件を追加し、`dangerouslyDisableSandbox: true` を禁じる tooling note を spawn 時に必ず含めるよう明記
- fixer spawn / re-review サイトにも同じ note を伝播する旨を注記（canonical な文面は Step 2 に 1 箇所）

## Why

SKILL.md 本文のルールは orchestrator 向けで、Agent tool で spawn される subagent の system prompt に自動伝播しない。結果、subagent が defensive に bypass flag を付けてユーザーに承認プロンプトが連発する問題が 2026-04-20〜21 outandhook session で再現（#245）。Option A（prompt template への明示記載）を採用。

## Test plan

- [x] 静的: spawn サイト 3 箇所（4 reviewers / fixer / re-review）すべてから tooling note 参照があることを確認
- [ ] ドッグフード: 本 PR 自体の pr-review-team 走行で subagent 承認プロンプトが発生しないことを確認

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)