### PR TITLE
feat(code): autopilot violations memory + skip-declare + retrospective reconciliation

### DIFF
--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -8,6 +8,7 @@
 #   autopilot-state.sh set <key> <value>           # e.g. set phase audit
 #   autopilot-state.sh advance                     # move to next phase
 #   autopilot-state.sh metric <name> <value>       # update metrics.{name}
+#   autopilot-state.sh skip-declare <phase> <reason>  # append skip_log entry
 #   autopilot-state.sh cleanup
 #
 # Schema (v1):
@@ -197,16 +198,36 @@ cmd_cleanup() {
   echo "cleaned up: $STATE_FILE"
 }
 
+# Append a skip declaration to .skip_log[]. Purely additive; does NOT advance
+# the phase or interact with the Stop hook. Callers are expected to still run
+# `advance` afterward. The retrospective step audits skip_log against the
+# session transcript.
+cmd_skip_declare() {
+  local phase="$1" reason="${2:-}"
+  [ -n "$phase" ] && [ -n "$reason" ] || die "usage: skip-declare <phase> <reason>"
+  [[ "$phase" =~ ^[a-z][a-z0-9-]*$ ]] || die "invalid phase: $phase"
+  [ -f "$STATE_FILE" ] || die "no state file; run init first"
+  local now; now=$(iso_now)
+  local tmp; tmp=$(state_mktemp) || die "state_mktemp failed"
+  trap 'rm -f "$tmp"' RETURN
+  jq --arg phase "$phase" --arg reason "$reason" --arg now "$now" \
+     '.skip_log = ((.skip_log // []) + [{phase: $phase, reason: $reason, declared_at: $now}])
+      | .updated_at = $now' \
+     "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+  echo "skip-declared: $phase"
+}
+
 sub="${1:-}"
 shift || true
 case "$sub" in
-  init)    cmd_init "$@" ;;
-  read)    cmd_read ;;
-  get)     cmd_get "$@" ;;
-  set)     cmd_set "$@" ;;
-  advance) cmd_advance ;;
-  metric)  cmd_metric "$@" ;;
-  cleanup) cmd_cleanup ;;
-  "" )     die "subcommand required: init|read|get|set|advance|metric|cleanup" ;;
-  *)       die "unknown subcommand: $sub" ;;
+  init)         cmd_init "$@" ;;
+  read)         cmd_read ;;
+  get)          cmd_get "$@" ;;
+  set)          cmd_set "$@" ;;
+  advance)      cmd_advance ;;
+  metric)       cmd_metric "$@" ;;
+  cleanup)      cmd_cleanup ;;
+  skip-declare) cmd_skip_declare "$@" ;;
+  "" )          die "subcommand required: init|read|get|set|advance|metric|cleanup|skip-declare" ;;
+  *)            die "unknown subcommand: $sub" ;;
 esac

--- a/plugins/code/scripts/autopilot-state.sh
+++ b/plugins/code/scripts/autopilot-state.sh
@@ -206,12 +206,20 @@ cmd_skip_declare() {
   local phase="$1" reason="${2:-}"
   [ -n "$phase" ] && [ -n "$reason" ] || die "usage: skip-declare <phase> <reason>"
   [[ "$phase" =~ ^[a-z][a-z0-9-]*$ ]] || die "invalid phase: $phase"
+  # Reject whitespace-only or too-short reasons: zero-effort declarations like
+  # "n/a" or " " defeat the commitment device purpose.
+  local trimmed="${reason#"${reason%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  (( ${#trimmed} >= 10 )) || die "reason must be at least 10 non-whitespace chars (got: '$reason')"
   [ -f "$STATE_FILE" ] || die "no state file; run init first"
   local now; now=$(iso_now)
   local tmp; tmp=$(state_mktemp) || die "state_mktemp failed"
   trap 'rm -f "$tmp"' RETURN
+  # Cap skip_log at 500 most-recent entries to prevent unbounded growth across
+  # many autopilot runs. Retrospective still sees the latest run's entries.
   jq --arg phase "$phase" --arg reason "$reason" --arg now "$now" \
      '.skip_log = ((.skip_log // []) + [{phase: $phase, reason: $reason, declared_at: $now}])
+      | .skip_log = (if (.skip_log | length) > 500 then .skip_log[-500:] else .skip_log end)
       | .updated_at = $now' \
      "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
   echo "skip-declared: $phase"

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -68,7 +68,7 @@ Three behaviors to distinguish at every phase:
 | **Skip** a phase because the project state makes it a legitimate no-op (e.g., no code changes for `simplify` to review) | ⚠️ Allowed **with declaration** | `autopilot-state.sh skip-declare <phase> "<reason>"` — then `advance`. Retrospective reviews the declaration. |
 | **Silent skip** — proceed past a phase without its skill invocation and without a declaration | ❌ Spec violation | Retrospective detects via transcript grep and appends an entry to the violations memory file. |
 
-### Rationalization patterns to reject (Issue #247 — three prior recurrences)
+### Rationalization patterns to reject (documented in Issue #247)
 
 - "This PR is docs-only, so `simplify` adds no value." → Invoke `simplify` anyway (cheap, maintains discipline); or `skip-declare` with a concrete reason if truly no-op.
 - "One `pr-review-toolkit:code-reviewer` agent is enough; four is overkill." → No. `code:pr-review-team` specifies four parallel reviewers for a reason.

--- a/plugins/code/skills/autopilot/SKILL.md
+++ b/plugins/code/skills/autopilot/SKILL.md
@@ -40,6 +40,41 @@ Exit code semantics:
     4. auto mode 不要な場合は /code:dev-cycle を使用
   ```
 
+## Step 0.5: Read project-local violations memory (Issue #248)
+
+Before Step 1, read this project's autopilot violations log as a commitment device:
+
+```bash
+# Locate project memory dir. Claude Code replaces both `/` and `_` with `-`
+# in the current working directory path and keeps the leading `-`.
+PROJECT_SLUG=$(pwd | sed 's|[/_]|-|g')
+VIOLATIONS_FILE="$HOME/.claude/projects/${PROJECT_SLUG}/memory/feedback_autopilot_violations.md"
+```
+
+- If the file exists: **Read it with the Read tool**. The Known violations section lists past spec bypasses in this project. Do not repeat them.
+- If it does not exist (first autopilot run in this project): bootstrap by copying
+  `${CLAUDE_PLUGIN_ROOT}/skills/autopilot/references/violations-skill-template.md`
+  to that path, then read it.
+
+The retrospective phase appends new violation entries here when it detects silent skips. Treating this as required reading makes each entry a concrete commitment carried into the next run.
+
+## Stop vs Skip — what counts as a violation
+
+Three behaviors to distinguish at every phase:
+
+| Action | Status | Recording |
+|--------|--------|-----------|
+| **Stop** when blocked (missing dependency, test failure, external API down, etc.) | ✅ Allowed | `autopilot-state.sh set last_failure '"<reason>"'` — then stop. User resumes after fixing. |
+| **Skip** a phase because the project state makes it a legitimate no-op (e.g., no code changes for `simplify` to review) | ⚠️ Allowed **with declaration** | `autopilot-state.sh skip-declare <phase> "<reason>"` — then `advance`. Retrospective reviews the declaration. |
+| **Silent skip** — proceed past a phase without its skill invocation and without a declaration | ❌ Spec violation | Retrospective detects via transcript grep and appends an entry to the violations memory file. |
+
+### Rationalization patterns to reject (Issue #247 — three prior recurrences)
+
+- "This PR is docs-only, so `simplify` adds no value." → Invoke `simplify` anyway (cheap, maintains discipline); or `skip-declare` with a concrete reason if truly no-op.
+- "One `pr-review-toolkit:code-reviewer` agent is enough; four is overkill." → No. `code:pr-review-team` specifies four parallel reviewers for a reason.
+- "The user said 『走り切って』, so I can merge autonomously." → No. Merge is always gated on an explicit "マージして" / "merge" instruction from the user.
+- "I can run several `advance` calls in a row to catch up." → No. Each phase needs its own skill invocation between advances.
+
 ## Step 1: Resolve input
 
 `$ARGUMENTS` is interpreted as natural language. No flags.

--- a/plugins/code/skills/autopilot/references/violations-skill-template.md
+++ b/plugins/code/skills/autopilot/references/violations-skill-template.md
@@ -1,0 +1,40 @@
+---
+name: autopilot-violations
+description: Project-local log of autopilot phase bypasses and skip declarations. Read at /code:autopilot start as a commitment device. Authored by the retrospective phase; do not hand-edit unless fixing formatting.
+type: feedback
+---
+
+# Autopilot Violations — project-local
+
+## Purpose
+
+Past failures observed while running `/code:autopilot` in **this specific project**. Read this at the start of every autopilot run. Do not repeat the patterns listed below.
+
+## Rules (always applicable, regardless of entries below)
+
+1. **Stopping is allowed and expected when blocked**. Record `last_failure` via `autopilot-state.sh` and stop cleanly.
+2. **Silently skipping a phase is a spec violation**. If a phase legitimately needs to be skipped, declare it first:
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-state.sh skip-declare <phase> "<reason>"
+   ```
+   The retrospective audits both the declaration and the transcript; silent skips are logged here on detection.
+3. **`gh pr merge` is never automatic**. The spec's "complete" state means ready-to-merge, not merged. Wait for an explicit user instruction (e.g. "マージして" or "merge").
+
+## Known violations
+
+<!--
+Append new entries here via the retrospective reconciliation step.
+Keep most recent first. Consolidate or trim when this section exceeds ~30 entries.
+
+Entry template:
+
+## <YYYY-MM-DD> — <short title>
+
+**Phase**: <phase name>
+**Outcome**: SILENT_SKIP | PARTIAL_EXEC | UNAUTHORIZED_ACTION
+**Detection**: <what tipped off the audit>
+**Rationalization used**: <the excuse the prior run gave, if known>
+**Remediation for future runs**: <what should happen instead>
+-->
+
+_No entries yet. Retrospective will append here on detection._

--- a/plugins/code/skills/retrospective/SKILL.md
+++ b/plugins/code/skills/retrospective/SKILL.md
@@ -54,6 +54,50 @@ Code quality and architecture analysis. For detailed prompt, read `${CLAUDE_PLUG
 
 Output: Strengths, Weaknesses, Recommendations, Metrics.
 
+### Step 2.5: Autopilot phase reconciliation (Issue #248)
+
+Runs only when `.claude/autopilot.state.json` exists (autopilot-driven runs). Fail open: any error here logs and continues — never blocks retrospective.
+
+Goal: detect silent phase skips by comparing the session transcript against expected skill invocations and the declared `skip_log[]`.
+
+```bash
+STATE=.claude/autopilot.state.json
+[ -f "$STATE" ] || skip_step
+# Claude Code project slug: replace `/` and `_` with `-`, keep leading `-`.
+PROJECT_SLUG=$(pwd | sed 's|[/_]|-|g')
+TRANSCRIPT=$(ls -t "$HOME/.claude/projects/${PROJECT_SLUG}"/*.jsonl 2>/dev/null | head -1)
+VIOLATIONS="$HOME/.claude/projects/${PROJECT_SLUG}/memory/feedback_autopilot_violations.md"
+# Fail-open guard: if no transcript exists (first run / sandbox), skip reconciliation.
+[ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] || skip_step
+```
+
+For each phase in the pipeline (`sprint | audit | simplify | ship | post-pr-review | retrospective`):
+
+| Expected Skill | Detection patterns in transcript (`"name":"Skill"` + `"skill":"<x>"`) |
+|----------------|----|
+| sprint | `code:sprint-impl` |
+| audit | `code:audit-compliance` |
+| simplify | `simplify` |
+| ship | `code:shipping-pr` |
+| post-pr-review | `code:pr-review-team` |
+
+Decision table per phase:
+
+| Transcript has skill invocation | `skip_log` has entry | Verdict |
+|---|---|---|
+| yes | — | OK (skill was invoked) |
+| no | yes | Declared skip — note for curation |
+| no | no | **SILENT_SKIP violation** — append entry to `$VIOLATIONS` |
+
+When a SILENT_SKIP is detected:
+1. Append an entry to `$VIOLATIONS` using the template format (date, phase, outcome, detection, rationalization unknown unless recoverable from transcript, remediation hint).
+2. Call `acm_record_signal` if the ACM MCP is available, tagging `autopilot_phase_bypass`, `phase:<name>`, strength high. Skip silently if the tool isn't registered.
+3. Do NOT fix the violation in this run (ship has already happened). The goal is to record for the next run's Step 0.5 commitment device.
+
+Transcript grep caveats (documented so false positives are understood):
+- The transcript jsonl format is not a stable Claude Code API. Future schema drift may require adjusting the patterns.
+- "Skill invocation present" is a lower bound — partial or wrong-arity invocations may still pass this check. Reviewer analysis in Step 2 is the complementary signal for quality.
+
 ### Step 3: Integrate Reports
 
 Integrate both agent reports:
@@ -62,6 +106,7 @@ Integrate both agent reports:
 2. **workflow-recording.md update**: Add phase metrics
 3. **Learnings optimization**: Read and optimize `docs/dev-cycle-learnings.md` (see Learnings PDCA below)
 4. **MEMORY.md update**: Record process lessons
+5. **Violations memory curation**: If `$VIOLATIONS` now exceeds ~30 entries or contains near-duplicates, consolidate older entries by pattern. Newest entries remain verbatim.
 
 ### Step 4: Fix (if needed)
 

--- a/plugins/code/skills/retrospective/SKILL.md
+++ b/plugins/code/skills/retrospective/SKILL.md
@@ -63,12 +63,24 @@ Goal: detect silent phase skips by comparing the session transcript against expe
 ```bash
 STATE=.claude/autopilot.state.json
 [ -f "$STATE" ] || skip_step
-# Claude Code project slug: replace `/` and `_` with `-`, keep leading `-`.
+# Claude Code project slug: replace `/` and `_` with `-`. The leading `-`
+# appears naturally because pwd starts with `/`.
 PROJECT_SLUG=$(pwd | sed 's|[/_]|-|g')
 TRANSCRIPT=$(ls -t "$HOME/.claude/projects/${PROJECT_SLUG}"/*.jsonl 2>/dev/null | head -1)
 VIOLATIONS="$HOME/.claude/projects/${PROJECT_SLUG}/memory/feedback_autopilot_violations.md"
-# Fail-open guard: if no transcript exists (first run / sandbox), skip reconciliation.
-[ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] || skip_step
+# Fail-open guard: if no transcript exists (first run / sandbox / slug drift),
+# log to stderr for visibility then skip reconciliation. Do NOT block retrospective.
+if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
+  echo "[retrospective] autopilot reconciliation skipped: no transcript at $HOME/.claude/projects/${PROJECT_SLUG}/" >&2
+  skip_step
+fi
+```
+
+When calling `acm_record_signal`, log whether ACM is available so silent failures in analytics are visible:
+
+```text
+If the `mcp__plugin_acm_acm__acm_record_signal` tool is registered, call it with the violation details.
+Otherwise, emit `[retrospective] acm_record_signal unavailable — violation recorded to file only` to stderr and continue.
 ```
 
 For each phase in the pipeline (`sprint | audit | simplify | ship | post-pr-review | retrospective`):


### PR DESCRIPTION
## Summary

Issue #247 の 3 度目の autopilot phase bypass 再発に対する Phase 1 対策。**purely additive** で既存 API に破壊的変更なし。

- `autopilot-state.sh skip-declare <phase> <reason>` 新 subcommand（既存 `advance` 等は unchanged）
- autopilot SKILL Step 0.5: project-local violations memory を必須 Read（bootstrap template あり）
- autopilot SKILL: 「Stop vs Skip」セクションで rationalization table を明示
- retrospective SKILL Step 2.5: session transcript 監査 + violations memory への append + `acm_record_signal`

## Why

3 度目の phase bypass（orbitscore PR #149）。advisor / Codex 相談の結果、hook 追加は project direction (PR #227 empirical removal pattern) と矛盾するため回避。Phase 1 は回帰リスクゼロの additive 改修のみ。Phase 2（structured violations / `advance` → `start`/`complete` / intent gate）は empirical evidence 蓄積後に別 issue で検討。

## Test plan

- [x] `skip-declare` 単体動作確認（phase 不変、skip_log append、複数 entry 蓄積）
- [x] `PROJECT_SLUG` 変換実測（`/` と `_` 両方を `-` に置換、leading `-` 保持）
- [x] 既存 `advance` / `set` / `metric` / `cleanup` の動作が変わらないことを code diff で確認
- [x] fail-open guard (transcript 不在時に skip_step) を retrospective snippet に追加
- [ ] 本 PR 自体の autopilot 走行で pipeline が従来通り動作すること（dogfood、本 PR 作成で進行中）

## Non-goals (Phase 2 deferred)

- 構造化 violations file（YAML entry with id/phase/condition/allowed_action）
- `advance` → `start`/`complete` 移行
- `intent.merge_pr` state gate
- `skip-declare` reason の violation-id 引用強制
- 新規 hook 追加

## Evaluation criteria for Phase 2 escalation

次の数回 autopilot 走行で観測:
- 違反発生時、retrospective が catch して violations memory に append したか
- violations memory が次 run の Step 0.5 で読まれ top-of-mind になったか
- Silent skip の再発率 / false positive（transcript 解析誤検知）件数

2-3 回で違反再発かつ catch もできない場合、Phase 2 に escalate。

Closes #248
Refs #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)