### PR TITLE
chore(code): prose refinements to checkup and pr-review-team

### DIFF
--- a/plugins/code/skills/checkup/SKILL.md
+++ b/plugins/code/skills/checkup/SKILL.md
@@ -76,6 +76,14 @@ from the output.
 End with a brief neutral note, e.g.:
 `Review each item and decide; this list does not declare readiness.`
 
+Then add a one-line invitation so the user knows they can delegate the
+per-item inspection manually if they want it:
+
+`If you'd like me to actually inspect each item and report status, say "check".`
+
+The skill itself still does not verify. Inspection only happens on the user's
+explicit follow-up ("check"), keeping this skill as a reminder.
+
 ## Rationalization patterns to reject
 
 - "Looks clean to me, all done." — not this skill's call to make

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -9,6 +9,21 @@ user-invocable: false
 
 # PR Review Team
 
+**MANDATORY first step — BEFORE any Agent / Read / bash work:**
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR番号>
+```
+
+`verify-workflow.sh` (Stop hook) refuses to release control if state
+initialisation did not happen before the review loop ran. Retroactively
+creating the state file after agents have already spawned only satisfies the
+hook's format check; it does NOT reconstruct the iteration evidence the hook
+is meant to guarantee. If you skipped init, you have to restart the loop,
+not paper over it. Run init now.
+
+---
+
 **MANDATORY**: This skill runs a complete review-fix-re-review loop using Subagents (NOT Agent Teams).
 
 The leader MUST:


### PR DESCRIPTION
Refs #263. Follow-up to PR #262 (lean code plugin).

## Summary

- **checkup**: add a one-line invitation so the user knows they can follow up with `check` for actual inspection. Skill remains a reminder, not a verifier.
- **pr-review-team**: promote `pr-review-state.sh init <PR>` to a MANDATORY first-step banner at the top, before the existing Step outline.

## Why

Issue #263 observed a real-run pattern where the leader skipped `pr-review-state.sh init`, ran the review loop, declared convergence, and was only then caught by the Stop hook — resulting in retroactive state fill that satisfied the hook's format but did not reconstruct iteration evidence. The fix is a tiny prose elevation that makes the first-step MANDATORY visible before any leader shortcut can engage.

Checkup's parallel clarification prevents the opposite failure mode (leader inferring "done" status without being asked) while still letting the user trigger inspection with a single word.

## Test plan

- [x] `bats plugins/code/tests/` — only the pre-existing `pr-review-team/SKILL.md` body-length failure remains (this PR adds ~15 lines to that file, so the lint number grew but the failure itself was pre-existing). Out of scope for this PR.
- [ ] Observe next `/code:pr-review-team` run under auto mode — the MANDATORY banner should be visible enough to prevent the retroactive-fill pattern reported in #263.

## Scope

Documentation prose only. No script, hook, or test changes.