### PR TITLE
feat(ask-gemini): migrate from Gemini CLI to Antigravity CLI (agy)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "ask-gemini",
-      "description": "Google Gemini CLI integration for web search",
+      "description": "Google Antigravity CLI (agy) integration for web search (formerly Gemini CLI)",
       "source": "./plugins/ask-gemini",
       "category": "productivity",
       "homepage": "https://github.com/signalcompose/claude-tools/tree/main/plugins/ask-gemini"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ One command. Four stages run autonomously.
 
 2. **Official Plugin System Compliance**: Built on Claude Code's plugin system (skills, commands, hooks, agents). No custom runtime or framework required.
 
-3. **External CLI Bridge**: Integrates external CLI tools (Codex, Gemini, Kiro) as Claude Code plugins, bringing their capabilities into the same workflow.
+3. **External CLI Bridge**: Integrates external CLI tools (Codex, Antigravity, Kiro) as Claude Code plugins, bringing their capabilities into the same workflow.
 
 ## Available Plugins
 
@@ -69,7 +69,7 @@ One command. Four stages run autonomously.
 |--------|----------|-------------|
 | [cvi](./plugins/cvi) | `/cvi:speak`, `/cvi:lang`, `/cvi:check` | Voice notifications for Claude Code on macOS |
 | [ask-codex](./plugins/ask-codex) | `/ask-codex:research`, `/ask-codex:review` | OpenAI Codex CLI integration for research and code review |
-| [ask-gemini](./plugins/ask-gemini) | `/ask-gemini:search` | Google Gemini CLI integration for web search |
+| [ask-gemini](./plugins/ask-gemini) | `/ask-gemini:search` | Google Antigravity CLI (agy) integration for web search (formerly Gemini CLI) |
 | [ask-kiro](./plugins/ask-kiro) | `/ask-kiro:research` | AWS Kiro CLI integration for AWS expert assistance |
 | [chezmoi](./plugins/chezmoi) | `/chezmoi:check`, `/chezmoi:sync` | Dotfiles management integration using chezmoi |
 | [utils](./plugins/utils) | `/utils:clear-plugin-cache` | Utility commands for plugin cache management |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ claude-tools/
 | code | Direct | plugins/code | コードレビュー |
 | utils | Direct | plugins/utils | ユーティリティ |
 | ask-codex | Direct | plugins/ask-codex | Codex統合 |
-| ask-gemini | Direct | plugins/ask-gemini | Gemini統合 |
+| ask-gemini | Direct | plugins/ask-gemini | Antigravity CLI (agy) 統合 |
 | ask-kiro | Direct | plugins/ask-kiro | Kiro統合 |
 | x-article | Direct | plugins/x-article | X Articles投稿自動化 |
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -25,7 +25,7 @@ claude-tools/
 │   ├── code/            # コードレビュー
 │   ├── utils/           # ユーティリティ
 │   ├── ask-codex/       # Codex統合
-│   ├── ask-gemini/      # Gemini統合
+│   ├── ask-gemini/      # Antigravity CLI (agy) 統合
 │   └── ask-kiro/        # Kiro統合
 ├── docs/                # ドキュメント
 │   ├── INDEX.md

--- a/plugins/ask-gemini/.claude-plugin/plugin.json
+++ b/plugins/ask-gemini/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "ask-gemini",
-  "description": "Google Gemini CLI integration for web search",
+  "description": "Google Antigravity CLI (agy) integration for web search (formerly Gemini CLI)",
   "author": {
     "name": "Signal compose",
     "email": "contact@signalcompose.com"
   },
   "repository": "https://github.com/signalcompose/claude-tools",
   "license": "MIT",
-  "keywords": ["gemini", "google", "web-search", "ai"]
+  "keywords": ["antigravity", "agy", "gemini", "google", "web-search", "ai"]
 }

--- a/plugins/ask-gemini/README.md
+++ b/plugins/ask-gemini/README.md
@@ -1,26 +1,43 @@
-# Gemini Search Plugin
+# ask-gemini — Web Search Plugin
 
-Google Gemini CLI integration for web search in Claude Code.
+Google Antigravity CLI (`agy`) integration for web search in Claude Code.
+
+> **Migration note:** Google transitioned the Gemini CLI to the **Antigravity CLI**
+> (binary: `agy`). Gemini CLI stopped serving requests on **2026-06-18** for
+> Google AI Pro/Ultra and free-tier users. This plugin now drives `agy`.
+> The command name `/ask-gemini:search` is unchanged.
 
 ## Features
 
-- Web search using Gemini CLI
+- Web search using Antigravity CLI (`agy`)
 - Forked context to avoid main context pollution
-- 60-second timeout for reliability
+- 120-second timeout for reliability
 
 ## Prerequisites
 
-### Install Gemini CLI
+### Install Antigravity CLI
 
 ```bash
-npm install -g @google/gemini-cli
-# or use npx directly
-npx @google/gemini-cli
+curl -fsSL https://antigravity.google/cli/install.sh | bash
 ```
 
-### Authenticate
+The installer places the `agy` binary in `~/.local/bin` and adds it to your PATH.
 
-Run `gemini` once to complete OAuth authentication with your Google account.
+### Sign in
+
+Run `agy` once to complete browser-based OAuth sign-in with your Google account.
+
+```bash
+agy
+```
+
+### (Optional) Import old Gemini settings
+
+If you used the legacy Gemini CLI, you can import its configuration:
+
+```bash
+agy plugin import gemini
+```
 
 ## Installation
 
@@ -50,47 +67,49 @@ The `gemini-search` skill is automatically available for Claude to use when web 
 
 ## How It Works
 
-1. The plugin checks if Gemini CLI is installed and authenticated
-2. Executes the search query using `gemini-2.5-flash-lite` model (default)
+1. The plugin checks if Antigravity CLI (`agy`) is installed and signed in
+2. Wraps the query in a web-search prompt and runs `agy --print "<prompt>" </dev/null`
 3. Returns comprehensive web search results
 4. Results are processed in a forked context to keep the main conversation clean
+
+> The `</dev/null` redirect is required: the prompt is passed as the `--print`
+> argument, but `agy --print` still reads stdin and would otherwise block forever
+> in a non-TTY context (such as Claude Code's Bash tool) waiting for EOF.
 
 ## Configuration
 
 ### Default Model
 
-The plugin uses `gemini-2.5-flash-lite` by default, which offers:
-- Stable availability and good rate limits
-- Cost-effective pricing
-- Fast response times
+The plugin uses the Antigravity CLI default model, which provides grounded web
+search out of the box. No model flag is passed by default.
 
 ### Custom Model
 
-Override the default model with the `GEMINI_MODEL` environment variable:
+Override the model with the `AGY_MODEL` environment variable:
 
 ```bash
-export GEMINI_MODEL=gemini-2.5-flash
+export AGY_MODEL="Gemini 3.5 Flash (Low)"
 ```
 
-Available models: `gemini-2.5-flash-lite` (default), `gemini-2.5-flash`, `gemini-2.5-pro`
+Run `agy models` to list the available model names for your account.
 
 ## Troubleshooting
 
-### Gemini CLI not found
+### `agy` not found
 
-Install Gemini CLI using npm or brew:
+Install Antigravity CLI:
 
 ```bash
-npm install -g @google/gemini-cli
+curl -fsSL https://antigravity.google/cli/install.sh | bash
 ```
 
-### Authentication failed
+### Not signed in
 
-Run `gemini` in your terminal to complete OAuth authentication.
+Run `agy` in your terminal to complete browser sign-in.
 
 ### Search timeout
 
-The search has a 60-second timeout. Try a more specific query if searches are timing out.
+The search has a 120-second timeout. Try a more specific query if searches are timing out.
 
 ## License
 

--- a/plugins/ask-gemini/commands/search.md
+++ b/plugins/ask-gemini/commands/search.md
@@ -1,24 +1,30 @@
 ---
-description: "Web search using Gemini CLI"
+description: "Web search using Antigravity CLI (agy)"
 ---
 
-# Web Search via Gemini CLI
+# Web Search via Antigravity CLI (agy)
 
-Execute a web search using Google Gemini CLI.
+Execute a web search using Google Antigravity CLI (`agy`), the successor to the
+Gemini CLI.
 
 ## Step 1: Check Prerequisites
 
-First, verify Gemini CLI is installed and ready:
+First, verify Antigravity CLI (`agy`) is installed and signed in:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/check-gemini.sh
 ```
 
-If the check fails, guide the user through installation.
+If the check fails, guide the user through installation:
+
+```bash
+curl -fsSL https://antigravity.google/cli/install.sh | bash
+agy   # one-time browser sign-in
+```
 
 ## Step 2: Execute Search
 
-**IMPORTANT**: The Gemini CLI requires write access to configuration and cache directories that are blocked by Claude Code's sandbox. You MUST use `dangerouslyDisableSandbox: true` when executing this script. Without this, the Gemini CLI will fail with shell command errors.
+**IMPORTANT**: Antigravity CLI requires write access to configuration and cache directories (under `~/.gemini/antigravity-cli/`) that are blocked by Claude Code's sandbox. You MUST use `dangerouslyDisableSandbox: true` when executing this script. Without this, `agy` will fail with shell command errors.
 
 Run the search with the provided query:
 
@@ -39,6 +45,7 @@ After receiving search results:
 
 ## Error Handling
 
-- **Gemini not installed**: Provide installation instructions
-- **Authentication error**: Guide user to run `gemini` for OAuth
+- **`agy` not installed**: Provide installation instructions (`curl -fsSL https://antigravity.google/cli/install.sh | bash`)
+- **Not signed in**: Guide user to run `agy` once for browser sign-in
+- **Legacy Gemini CLI only**: Migrate to `agy`; optionally `agy plugin import gemini`
 - **Timeout**: Suggest retrying with a more specific query

--- a/plugins/ask-gemini/scripts/check-gemini.sh
+++ b/plugins/ask-gemini/scripts/check-gemini.sh
@@ -1,29 +1,60 @@
 #!/bin/bash
-# check-gemini.sh - Verify Gemini CLI installation and configuration
+# check-gemini.sh - Verify Antigravity CLI (agy) installation and configuration
+#
+# Background:
+#   Google transitioned "Gemini CLI" to "Antigravity CLI" (binary: agy).
+#   Gemini CLI stopped serving requests on 2026-06-18 for Google AI Pro/Ultra
+#   and free-tier users, so this plugin now uses `agy`.
+#   See: https://antigravity.google
+#
+# Output contract: all human-readable diagnostics go to stderr; stdout is left
+# clean so callers (gemini-search.sh) can include the search result verbatim.
+# Success/failure is signalled via the exit code.
 
 set -e
 set -o pipefail
 
-# Check if gemini command exists
-if ! command -v gemini &> /dev/null; then
-    echo "ERROR: Gemini CLI is not installed."
-    echo ""
-    echo "To install Gemini CLI:"
-    echo "  npm install -g @google/gemini-cli"
-    echo "  # or use npx directly"
-    echo "  npx @google/gemini-cli"
-    echo ""
-    echo "After installation, run 'gemini' to authenticate."
+INSTALL_CMD="curl -fsSL https://antigravity.google/cli/install.sh | bash"
+
+# Resolve agy: PATH first, then the default install location (~/.local/bin).
+# The installer adds ~/.local/bin to PATH via shell profiles, but a
+# non-interactive shell may not have sourced them yet.
+if command -v agy >/dev/null 2>&1; then
+    AGY_BIN="$(command -v agy)"
+elif [ -x "$HOME/.local/bin/agy" ]; then
+    AGY_BIN="$HOME/.local/bin/agy"
+else
+    AGY_BIN=""
+fi
+
+if [ -z "$AGY_BIN" ]; then
+    # agy is missing. If the legacy Gemini CLI is present, give a
+    # migration-focused message; otherwise a plain install message.
+    if command -v gemini >/dev/null 2>&1; then
+        echo "ERROR: Antigravity CLI (agy) is not installed, but the legacy Gemini CLI was found." >&2
+        echo "" >&2
+        echo "Google replaced Gemini CLI with Antigravity CLI. Gemini CLI stopped serving" >&2
+        echo "requests on 2026-06-18 (AI Pro/Ultra/free tier). Please migrate to 'agy':" >&2
+        echo "" >&2
+        echo "  1. Install Antigravity CLI:" >&2
+        echo "       $INSTALL_CMD" >&2
+        echo "  2. Sign in (one-time, opens a browser):" >&2
+        echo "       agy" >&2
+        echo "  3. (Optional) Import your old Gemini settings:" >&2
+        echo "       agy plugin import gemini" >&2
+        echo "" >&2
+        echo "After signing in, re-run your search." >&2
+        exit 1
+    fi
+
+    echo "ERROR: Antigravity CLI (agy) is not installed." >&2
+    echo "" >&2
+    echo "To install Antigravity CLI:" >&2
+    echo "  $INSTALL_CMD" >&2
+    echo "" >&2
+    echo "Then run 'agy' once to sign in (opens a browser for OAuth)." >&2
     exit 1
 fi
 
-# Note: GEMINI_API_KEY is the correct variable for Gemini CLI (not GOOGLE_API_KEY)
-# GOOGLE_API_KEY works with Gemini API libraries but NOT with Gemini CLI (known bug)
-# See: https://github.com/google-gemini/gemini-cli/issues/7557
-if [ -z "$GEMINI_API_KEY" ]; then
-    echo "INFO: GEMINI_API_KEY not set. Gemini CLI will use OAuth authentication."
-    echo "If not authenticated, run 'gemini' to complete OAuth setup."
-fi
-
-echo "OK: Gemini CLI is installed."
+echo "OK: Antigravity CLI (agy) is installed at $AGY_BIN." >&2
 exit 0

--- a/plugins/ask-gemini/scripts/gemini-search.sh
+++ b/plugins/ask-gemini/scripts/gemini-search.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
-# gemini-search.sh - Execute web search using Gemini CLI
+# gemini-search.sh - Execute web search using Antigravity CLI (agy)
+#
+# Replaces the legacy Gemini CLI (Google transitioned Gemini CLI -> Antigravity CLI).
+#
+# Key detail: the prompt is passed as the `--print` argument (NOT via stdin).
+# But `agy --print` still reads stdin, and in a non-TTY context (such as Claude
+# Code's Bash tool, which runs on a socket) it blocks forever waiting for EOF.
+# We redirect stdin from /dev/null so it gets an immediate EOF and prints the
+# response to stdout. Verified empirically: the prompt arg is honored and web
+# grounding works. A pseudo-TTY wrapper (`script`) is NOT needed and does not
+# work in that socket environment.
 
 set -e
 set -o pipefail
@@ -16,7 +26,14 @@ fi
 # Remove newlines and control characters that could manipulate prompt structure
 QUERY=$(echo "$RAW_QUERY" | tr -d '\n\r' | sed 's/[`$]//g')
 
-# Check Gemini CLI availability
+# Reject a query that sanitizes to empty (e.g. only `$` / backtick characters),
+# which the pre-sanitization -z check above would not catch.
+if [ -z "$QUERY" ]; then
+    echo "ERROR: Query is empty after sanitization (only stripped characters). Provide searchable text." >&2
+    exit 1
+fi
+
+# Check Antigravity CLI availability
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ ! -f "$SCRIPT_DIR/check-gemini.sh" ]; then
     echo "ERROR: check-gemini.sh not found in $SCRIPT_DIR"
@@ -25,10 +42,22 @@ if [ ! -f "$SCRIPT_DIR/check-gemini.sh" ]; then
 fi
 "$SCRIPT_DIR/check-gemini.sh" || exit 1
 
-# Execute gemini with web search prompt
-# Default model: gemini-2.5-flash-lite (stable, good rate limits, cost-effective)
-# Override with GEMINI_MODEL environment variable if needed
-MODEL="${GEMINI_MODEL:-gemini-2.5-flash-lite}"
+# Resolve agy binary (PATH first, then the default install location)
+if command -v agy >/dev/null 2>&1; then
+    AGY_BIN="$(command -v agy)"
+elif [ -x "$HOME/.local/bin/agy" ]; then
+    AGY_BIN="$HOME/.local/bin/agy"
+else
+    echo "ERROR: agy binary not found. Run check-gemini.sh for install instructions."
+    exit 1
+fi
+
+# Optional model override. By default we let agy pick its model (web grounding
+# works well with the default). Set AGY_MODEL to a name from `agy models`.
+MODEL_ARGS=()
+if [ -n "$AGY_MODEL" ]; then
+    MODEL_ARGS=(--model "$AGY_MODEL")
+fi
 
 # Determine timeout command (gtimeout for macOS with coreutils, timeout for Linux)
 if command -v gtimeout &> /dev/null; then
@@ -41,40 +70,36 @@ else
     echo "Command will run without timeout protection. On macOS: brew install coreutils" >&2
 fi
 
-# Execute with timeout (60 seconds) or without if no timeout command available
+PROMPT="WebSearch: $QUERY
+
+Please search the web and provide comprehensive, up-to-date information about the query above. Include:
+- Key findings and facts
+- Relevant sources (URLs when available)
+- Current/latest information
+- Summary of the most important points"
+
+# Execute with timeout (120 seconds) or without if no timeout command available.
+# NOTE: `</dev/null` is required (see header) to avoid a hang in non-TTY contexts.
 set +e  # Temporarily disable exit on error to capture exit code
 if [ -n "$TIMEOUT_CMD" ]; then
-    $TIMEOUT_CMD 60 gemini -m "$MODEL" --prompt "WebSearch: $QUERY
-
-Please search the web and provide comprehensive, up-to-date information about the query above. Include:
-- Key findings and facts
-- Relevant sources (URLs when available)
-- Current/latest information
-- Summary of the most important points"
+    $TIMEOUT_CMD 120 "$AGY_BIN" "${MODEL_ARGS[@]}" --print "$PROMPT" </dev/null
 else
-    # No timeout command available, run without timeout
-    gemini -m "$MODEL" --prompt "WebSearch: $QUERY
-
-Please search the web and provide comprehensive, up-to-date information about the query above. Include:
-- Key findings and facts
-- Relevant sources (URLs when available)
-- Current/latest information
-- Summary of the most important points"
+    "$AGY_BIN" "${MODEL_ARGS[@]}" --print "$PROMPT" </dev/null
 fi
 
 EXIT_CODE=$?
 set -e  # Re-enable exit on error
 
-if [ $EXIT_CODE -eq 124 ]; then
+if [ $EXIT_CODE -eq 124 ] && [ -n "$TIMEOUT_CMD" ]; then
     echo ""
-    echo "ERROR: Search timed out after 60 seconds."
+    echo "ERROR: Search timed out after 120 seconds."
     echo "Try a more specific query or check your network connection."
     exit 124
 elif [ $EXIT_CODE -ne 0 ]; then
     echo ""
-    echo "ERROR: Gemini CLI failed with exit code $EXIT_CODE"
-    echo "Run 'gemini --help' directly for troubleshooting."
-    echo "Common causes: authentication issues, network problems, rate limiting."
+    echo "ERROR: Antigravity CLI (agy) failed with exit code $EXIT_CODE"
+    echo "Run 'agy --help' directly for troubleshooting."
+    echo "Common causes: not signed in (run 'agy'), network problems, rate limiting."
     exit $EXIT_CODE
 fi
 

--- a/plugins/ask-gemini/skills/gemini-search/SKILL.md
+++ b/plugins/ask-gemini/skills/gemini-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gemini-search
 description: |
-  Web search using Google Gemini CLI.
+  Web search using Google Antigravity CLI (agy, formerly Gemini CLI).
   Use for: latest information, documentation lookup, current events,
   or when up-to-date web data is needed.
 context: fork
@@ -9,23 +9,35 @@ agent: Explore
 allowed-tools: Bash
 ---
 
-# Gemini Web Search Skill
+# Web Search Skill (Antigravity CLI)
 
 ## Overview
 
-This skill enables web search using Google Gemini CLI. Use it when you need:
+This skill enables web search using Google Antigravity CLI (`agy`), the
+successor to the Gemini CLI. Use it when you need:
 
 - Latest information not in training data
 - Current documentation or API references
 - Recent news or events
 - Up-to-date web data
 
+> Note: Google transitioned Gemini CLI to Antigravity CLI. Gemini CLI stopped
+> serving requests on 2026-06-18 for AI Pro/Ultra and free-tier users, so this
+> skill now drives the `agy` binary.
+
 ## Prerequisites
 
-Gemini CLI must be installed and authenticated. Run the check script first:
+Antigravity CLI (`agy`) must be installed and signed in. Run the check script first:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/check-gemini.sh
+```
+
+If `agy` is missing, install it and sign in:
+
+```bash
+curl -fsSL https://antigravity.google/cli/install.sh | bash
+agy   # one-time browser sign-in
 ```
 
 ## Usage
@@ -35,6 +47,12 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/check-gemini.sh
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/gemini-search.sh "<search query>"
 ```
+
+**IMPORTANT**: `agy` needs write access to its config/cache under
+`~/.gemini/antigravity-cli/`, which Claude Code's sandbox blocks. When running
+the script via the Bash tool, set `dangerouslyDisableSandbox: true`; otherwise
+`agy` exits non-zero with shell command errors even though it is installed and
+signed in.
 
 ### Examples
 
@@ -52,12 +70,12 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gemini-search.sh "AI regulation updates January 20
 ## Workflow
 
 1. **Check Prerequisites**
-   - Verify Gemini CLI installation
-   - Ensure authentication is complete
+   - Verify Antigravity CLI (`agy`) installation
+   - Ensure sign-in is complete
 
 2. **Execute Search**
    - Run gemini-search.sh with query
-   - Wait for results (60s timeout)
+   - Wait for results (120s timeout)
 
 3. **Process Results**
    - Summarize key findings
@@ -68,13 +86,17 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gemini-search.sh "AI regulation updates January 20
 
 | Error | Solution |
 |-------|----------|
-| Gemini CLI not found | Install via `npm install -g @google/gemini-cli` |
-| Authentication failed | Run `gemini` to complete OAuth |
-| Timeout | Retry with more specific query |
+| `agy` not found | Install: `curl -fsSL https://antigravity.google/cli/install.sh \| bash` |
+| Not signed in | Run `agy` once to complete browser sign-in |
+| Legacy Gemini CLI only | Migrate to `agy` (see install above); optionally `agy plugin import gemini` |
+| Timeout | Retry with a more specific query |
 
 ## Notes
 
-- Uses `gemini-2.5-flash-lite` model by default (stable, good rate limits)
-- Override with `GEMINI_MODEL` environment variable
-- 60-second timeout to prevent hanging
+- Uses the Antigravity CLI default model (web grounding works well with it)
+- Override with the `AGY_MODEL` environment variable (run `agy models` for names)
+- 120-second timeout to prevent hanging
+- The script runs `agy --print "<query>" </dev/null`; the stdin redirect is
+  required so `agy` does not block on a missing terminal in non-TTY contexts
+  (such as Claude Code's Bash tool)
 - Results are returned to the forked context to avoid main context pollution


### PR DESCRIPTION
## 概要

Google が Gemini CLI を **Antigravity CLI (`agy`)** へ移行し、Gemini CLI は **2026-06-18** に Pro/Ultra/無料枠のリクエスト処理を停止しました。`ask-gemini` プラグインのバックエンドを `agy` に置き換えます。

後方互換のため、コマンド名 `/ask-gemini:search`・スキル名 `gemini-search`・内部スクリプト名は維持しています。

## 主な変更

- **`scripts/gemini-search.sh`**: `agy --print "<prompt>" </dev/null` で実行。`</dev/null` は非TTY環境（Claude Code の Bash＝ソケット）での stdin ブロッキング回避に必須。`-m` 廃止に伴い `--model`（省略時は agy デフォルト、`AGY_MODEL` で上書き可）。
- **`scripts/check-gemini.sh`**: `agy` を検出。`gemini` のみ検出時はインストール＋サインインを促す移行メッセージを表示。診断は stderr へ分離し、検索結果への混入を防止。
- **`skills/SKILL.md` / `commands/search.md`**: agy 前提・サインイン・サンドボックス指示を更新。
- **`plugin.json` / `marketplace.json` / `README` / `docs`**: 表記を Antigravity CLI に更新。

## 検証（agy v1.0.11, macOS）

- 実バイナリで構文確認（`-p`/`--print`、`--model`、`</dev/null` で stdin ブロッキング回避）。
- 本番コマンド経路 `/ask-gemini:search` をライブ検証し、出典URL付きの grounded な検索結果を取得。
- 移行検出ブランチ・空クエリガード・stdout 非汚染を確認。
- xhigh コードレビュー（48エージェント）の指摘（stdout 汚染・vestigial 認証ゲート等）を反映。

## 補足

- このリポジトリは directory ソースのローカル開発版マーケットプレイス。`/plugin update` で feature ブランチの HEAD を取り込み、再起動なしでライブ検証済み。
- `agy` は独自 OAuth サインインが必要（`agy` 無引数）。旧設定は `agy plugin import gemini` で移行可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
