### PR TITLE
docs: remove stale references to removed code-plugin skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ One command. Four stages run autonomously.
 | Plugin | Commands | Description |
 |--------|----------|-------------|
 | [ypm](./plugins/ypm) | `/ypm:new`, `/ypm:update`, `/ypm:next` | Project management - setup wizard, status tracking, task prioritization |
-| [code](./plugins/code) | `/code:dev-cycle`, `/code:shipping-pr`, `/code:review-commit` | Autonomous dev lifecycle, code review, PR creation gate |
+| [code](./plugins/code) | `/code:pr-review-team`, `/code:refactor-team`, `/code:checkup` | Parallel PR review team, refactoring team, and pre-merge checklist reminder |
 
 ### Supporting Tools
 

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -261,10 +261,10 @@ Cannot reach github.com
 Please check your internet connection and try again.
 ```
 
-### code review-commit (1 reference)
+### code pr-review-team (1 reference)
 
 ```markdown
-For detailed review criteria, read `${CLAUDE_PLUGIN_ROOT}/skills/review-commit/references/review-criteria.md`.
+For the security checklist, read `${CLAUDE_PLUGIN_ROOT}/skills/pr-review-team/references/security-checklist.md`.
 ```
 
 ## Troubleshooting

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -34,7 +34,6 @@ holds the contract, but the explicit prompt reinforces it at the strong layer.
 | Hook | Trigger | Purpose |
 |------|---------|---------|
 | `check-gitignore-security.sh` | PreToolUse on `git commit*` | Blocks commit if `.gitignore` lacks the `code:security-patterns` marker. Suggests a one-line fix. |
-| `pr-review-team/scripts/verify-workflow.sh` | Stop | When a `pr-review-team` run is active, verifies the workflow completed properly (all reviewers ran, security checklist read, etc.) |
 
 No other hooks. No state files. No flag directories. No PostToolUse monitors.
 


### PR DESCRIPTION
## 概要

code プラグインのオーケストレーション群削除（#247 等）と #268 の verify-workflow.sh Stop hook 撤去に伴う、軽微な stale ドキュメント参照を修正。

- `README.md`: code プラグインのコマンド表を現行（pr-review-team / refactor-team / checkup）に修正。
- `plugins/code/README.md`: 撤去済み verify-workflow.sh Stop hook 行を Hooks 表から削除。
- `docs/progressive-disclosure.md`: 存在しない review-commit パス例を実在する pr-review-team/references/security-checklist.md に差し替え。

判断を要する陳腐化（Tier D: dev-cycle-guide / settings-triage-guide、Tier B: pr-review-state.sh の vestigial state 機構）は #270 で追跡。グローバル CLAUDE.md（chezmoi 管理）の review-commit 参照は別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)