### PR TITLE
feat(code): reduce pr-review-team token cost (conditional reviewers + scope discipline)

### DIFF
--- a/plugins/code/commands/pr-review-team.md
+++ b/plugins/code/commands/pr-review-team.md
@@ -4,7 +4,7 @@ description: Run team-based PR review with parallel specialized agents and itera
 
 # PR Review Team
 
-チーム編成による PR レビュー。4つの専門エージェントを並行起動し、CI 結果と統合して反復的に修正。
+チーム編成による PR レビュー。変更ファイルの種別に応じて最大4つの専門エージェントを条件起動し、CI 結果と統合して反復的に修正。
 
 ## 使い方
 
@@ -17,14 +17,14 @@ PR番号を省略すると、現在のブランチに紐づく PR を自動検�
 ## ワークフロー
 
 1. **対象PR特定** — PR番号の解決、プロジェクトコンテキスト検出
-2. **レビューチーム作成** — 4つの専門レビュアー + fixer を並行起動
-   - code-reviewer: コード品質・バグ検出
-   - silent-failure-hunter: サイレント障害・エラーハンドリング
-   - pr-test-analyzer: テストカバレッジ分析
-   - comment-analyzer: コメント正確性検証
+2. **レビューチーム作成** — `select-reviewers.sh` で変更ファイル種別を判定し、必要な専門レビュアーのみ並行起動（docs/config のみの PR は不要なレビュアーをスキップ）
+   - code-reviewer: コード品質・バグ検出（常時起動）
+   - silent-failure-hunter: サイレント障害・エラーハンドリング（コード変更時）
+   - pr-test-analyzer: テストカバレッジ分析（コード変更時）
+   - comment-analyzer: コメント正確性検証（コード/ドキュメント変更時）
 3. **CI結果収集** — `gh pr checks` で CI 状態を取得、失敗ログ分析
 4. **統合・修正** — レビュー結果 + CI 結果を fixer に一括送信
-5. **反復ループ** — Critical/Important = 0 かつセキュリティ全合格まで（最大5回）
+5. **反復ループ** — Critical/Important = 0 かつセキュリティ全合格まで（最大3回）
 6. **完了報告** — サマリー表示、マージはユーザー指示待ち
 
 ## 完了条件

--- a/plugins/code/scripts/select-reviewers.sh
+++ b/plugins/code/scripts/select-reviewers.sh
@@ -13,12 +13,21 @@
 # Reviewer names map to pr-review-toolkit subagents:
 #   code-reviewer  silent-failure-hunter  pr-test-analyzer  comment-analyzer
 #
-# Design (per measured cost + Fable review):
+# File classes:
+#   code   = source-code file (test-bearing language) OR anything unrecognized (fail-open)
+#   doc    = prose documentation (md, txt, rst, ...)
+#   config = structured/executable config (yaml, yml, toml, json, ini, ...) — CI
+#            workflows live here and CAN swallow failures / carry misleading comments,
+#            so config is NOT treated as inert.
+#   (lock/env/pure-data files carry no review value on their own.)
+#
+# Design (per measured cost + Fable review + PR #274 code review):
 #   - code-reviewer          : ALWAYS (generalist safety net; its failure aborts the review)
-#   - silent-failure-hunter  : run iff ≥1 source-code file changed (error handling is a code property)
-#   - pr-test-analyzer       : run iff ≥1 source-code file changed (its value is test coverage OF code;
-#                              a docs/config-only PR has nothing for it to analyze)
-#   - comment-analyzer       : run iff ≥1 code OR doc file changed (comment/prose accuracy)
+#   - pr-test-analyzer       : run iff ≥1 code file (its value is test coverage OF code;
+#                              docs/config-only PRs have nothing for it to analyze)
+#   - silent-failure-hunter  : run iff ≥1 code OR config file (error-swallowing lives in
+#                              code AND in CI/config yaml — e.g. `|| true`, continue-on-error)
+#   - comment-analyzer       : run iff ≥1 code, doc, OR config file (all carry comments/prose)
 # When file classification is uncertain, the file is treated as code (fail-open:
 # "when in doubt, run the reviewer"). On any error resolving the diff, launch ALL 4.
 
@@ -38,15 +47,15 @@ if [ -z "${PR_NUMBER}" ]; then
   fail_open "no PR number argument"
 fi
 
-# --relative keeps paths repo-relative; --name-only lists just the changed files.
+# --name-only lists just the changed file paths (one per line).
 FILES="$(gh pr diff "${PR_NUMBER}" --name-only 2>/dev/null)"
 if [ $? -ne 0 ] || [ -z "${FILES}" ]; then
   fail_open "gh pr diff returned no files"
 fi
 
-has_code=0   # source-code file (test-bearing language)
-has_doc=0    # documentation / prose
-# Anything that is neither clearly doc nor clearly config is treated as code.
+has_code=0     # source-code file (test-bearing language) or unrecognized (fail-open)
+has_doc=0      # prose documentation
+has_config=0   # structured/executable config (can carry logic or comments)
 while IFS= read -r f; do
   [ -z "$f" ] && continue
   base="$(basename -- "$f")"
@@ -59,36 +68,45 @@ while IFS= read -r f; do
   case "$ext" in
     md|markdown|mdx|txt|rst|adoc|org)
       has_doc=1 ;;
-    json|yaml|yml|toml|ini|cfg|conf|lock|env|properties)
-      : ;;  # config/data: no reviewer needs it on its own
+    json|yaml|yml|toml|ini|cfg|conf|properties)
+      has_config=1 ;;
+    lock|env)
+      : ;;  # pure data / secrets: no reviewer needs it on its own
     *)
       # any other extension: source code
       has_code=1 ;;
   esac
 done <<< "${FILES}"
 
-set=""
-add() { set="${set:+$set }$1"; }
+reviewers=""
+add() { reviewers="${reviewers:+$reviewers }$1"; }
 
 # code-reviewer: always
 add "code-reviewer"
 echo "DECISION: LAUNCH code-reviewer (always — generalist safety net)"
 
+# pr-test-analyzer: only when source code changed
 if [ "${has_code}" -eq 1 ]; then
-  add "silent-failure-hunter"
-  echo "DECISION: LAUNCH silent-failure-hunter (source-code files changed)"
   add "pr-test-analyzer"
   echo "DECISION: LAUNCH pr-test-analyzer (source-code files changed)"
 else
-  echo "DECISION: SKIP silent-failure-hunter (no source-code files — docs/config only)"
   echo "DECISION: SKIP pr-test-analyzer (no source-code files — nothing to analyze for test coverage)"
 fi
 
-if [ "${has_code}" -eq 1 ] || [ "${has_doc}" -eq 1 ]; then
-  add "comment-analyzer"
-  echo "DECISION: LAUNCH comment-analyzer (code or doc files changed)"
+# silent-failure-hunter: code or config (CI/config yaml can swallow failures)
+if [ "${has_code}" -eq 1 ] || [ "${has_config}" -eq 1 ]; then
+  add "silent-failure-hunter"
+  echo "DECISION: LAUNCH silent-failure-hunter (code or config files changed)"
 else
-  echo "DECISION: SKIP comment-analyzer (no code or doc files — config/data only)"
+  echo "DECISION: SKIP silent-failure-hunter (docs/data only — no error-handling surface)"
 fi
 
-echo "REVIEWERS: ${set}"
+# comment-analyzer: code, doc, or config (all carry comments/prose)
+if [ "${has_code}" -eq 1 ] || [ "${has_doc}" -eq 1 ] || [ "${has_config}" -eq 1 ]; then
+  add "comment-analyzer"
+  echo "DECISION: LAUNCH comment-analyzer (code, doc, or config files changed)"
+else
+  echo "DECISION: SKIP comment-analyzer (pure data/secret files only — no comments/prose)"
+fi
+
+echo "REVIEWERS: ${reviewers}"

--- a/plugins/code/scripts/select-reviewers.sh
+++ b/plugins/code/scripts/select-reviewers.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# select-reviewers.sh — Deterministically decide which review subagents to launch
+# based on the file types touched by a PR, to avoid spending tokens on reviewers
+# that cannot find anything in the changed files.
+#
+# Usage: bash select-reviewers.sh <PR番号>
+#
+# Output (stdout):
+#   DECISION lines (LAUNCH/SKIP with reason) for audit visibility — NOT silent.
+#   A final line:  REVIEWERS: <space-separated bare reviewer names>
+# The leader parses the REVIEWERS line and launches exactly that set.
+#
+# Reviewer names map to pr-review-toolkit subagents:
+#   code-reviewer  silent-failure-hunter  pr-test-analyzer  comment-analyzer
+#
+# Design (per measured cost + Fable review):
+#   - code-reviewer          : ALWAYS (generalist safety net; its failure aborts the review)
+#   - silent-failure-hunter  : run iff ≥1 source-code file changed (error handling is a code property)
+#   - pr-test-analyzer       : run iff ≥1 source-code file changed (its value is test coverage OF code;
+#                              a docs/config-only PR has nothing for it to analyze)
+#   - comment-analyzer       : run iff ≥1 code OR doc file changed (comment/prose accuracy)
+# When file classification is uncertain, the file is treated as code (fail-open:
+# "when in doubt, run the reviewer"). On any error resolving the diff, launch ALL 4.
+
+set -uo pipefail
+
+PR_NUMBER="${1:-}"
+ALL="code-reviewer silent-failure-hunter pr-test-analyzer comment-analyzer"
+
+fail_open() {
+  # Any uncertainty about the diff → launch everything (never under-review).
+  echo "DECISION: could not classify changed files ($1) — launching all reviewers (fail-open)"
+  echo "REVIEWERS: ${ALL}"
+  exit 0
+}
+
+if [ -z "${PR_NUMBER}" ]; then
+  fail_open "no PR number argument"
+fi
+
+# --relative keeps paths repo-relative; --name-only lists just the changed files.
+FILES="$(gh pr diff "${PR_NUMBER}" --name-only 2>/dev/null)"
+if [ $? -ne 0 ] || [ -z "${FILES}" ]; then
+  fail_open "gh pr diff returned no files"
+fi
+
+has_code=0   # source-code file (test-bearing language)
+has_doc=0    # documentation / prose
+# Anything that is neither clearly doc nor clearly config is treated as code.
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  base="$(basename -- "$f")"
+  if [[ "$base" != *.* ]]; then
+    # no extension (e.g. Makefile, Dockerfile, LICENSE) — treat as code (fail-open)
+    has_code=1
+    continue
+  fi
+  ext="$(printf '%s' "${base##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    md|markdown|mdx|txt|rst|adoc|org)
+      has_doc=1 ;;
+    json|yaml|yml|toml|ini|cfg|conf|lock|env|properties)
+      : ;;  # config/data: no reviewer needs it on its own
+    *)
+      # any other extension: source code
+      has_code=1 ;;
+  esac
+done <<< "${FILES}"
+
+set=""
+add() { set="${set:+$set }$1"; }
+
+# code-reviewer: always
+add "code-reviewer"
+echo "DECISION: LAUNCH code-reviewer (always — generalist safety net)"
+
+if [ "${has_code}" -eq 1 ]; then
+  add "silent-failure-hunter"
+  echo "DECISION: LAUNCH silent-failure-hunter (source-code files changed)"
+  add "pr-test-analyzer"
+  echo "DECISION: LAUNCH pr-test-analyzer (source-code files changed)"
+else
+  echo "DECISION: SKIP silent-failure-hunter (no source-code files — docs/config only)"
+  echo "DECISION: SKIP pr-test-analyzer (no source-code files — nothing to analyze for test coverage)"
+fi
+
+if [ "${has_code}" -eq 1 ] || [ "${has_doc}" -eq 1 ]; then
+  add "comment-analyzer"
+  echo "DECISION: LAUNCH comment-analyzer (code or doc files changed)"
+else
+  echo "DECISION: SKIP comment-analyzer (no code or doc files — config/data only)"
+fi
+
+echo "REVIEWERS: ${set}"

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -60,8 +60,22 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-state.sh init <PR番号>
 
 ## Step 2: Parallel Review (Subagents)
 
-**MANDATORY**: Launch ALL 4 reviewers in a SINGLE message using parallel Agent tool calls.
-Do NOT use TeamCreate or Task tool. Use the Agent tool directly.
+### Select reviewers (token discipline)
+
+Run the deterministic selector FIRST and launch only the reviewers it returns:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/select-reviewers.sh <PR番号>
+```
+
+Parse the `REVIEWERS:` line. `code-reviewer` is ALWAYS included. Docs/config-only
+PRs skip reviewers that have nothing to analyze in the changed files (e.g. a
+Markdown-only PR skips `silent-failure-hunter` and `pr-test-analyzer`). The script
+prints a `DECISION:` line per reviewer — do NOT drop any reviewer it did not skip,
+and do NOT add one it skipped. On any failure it fails open (all 4).
+
+**MANDATORY**: Launch ALL selected reviewers in a SINGLE message using parallel
+Agent tool calls. Do NOT use TeamCreate or Task tool. Use the Agent tool directly.
 
 🔴 **Subagent prompt requirement (Issue #245)** — Agent tool で spawn される subagent は orchestrator の SKILL 本文を見ない。以下のガード文をすべての subagent prompt に **必ず含める**（reviewers, fixer, re-reviewers 共通）:
 
@@ -75,12 +89,30 @@ breaks the review flow.
 
 省略すると subagent が `gh pr diff` 等で defensive に bypass を要求し、ユーザーに承認プロンプトが連発する。
 
-Launch in parallel (one message, 4 Agent tool calls):
+🔴 **Review scope discipline (token cost)** — include this block VERBATIM in every
+reviewer / re-reviewer prompt (in addition to the Tooling note above). It curbs the
+largest hidden cost: reviewers freely exploring files outside the diff.
+
+```
+Scope: base your review ONLY on `gh pr diff <PR>` and the changed files it lists.
+Do NOT explore or read files the diff does not touch or directly reference.
+Output: return ONLY findings you hold at >=80% confidence, each as one line
+`severity | file:line | issue`. No prose preamble, no summary, no restating the diff.
+```
+
+Do NOT add this scope block to the fixer prompt — the fixer needs to read
+surrounding code to apply correct fixes.
+
+Launch in parallel (one message, one Agent call per SELECTED reviewer):
 
 1. `Agent(subagent_type: "pr-review-toolkit:code-reviewer", model: "sonnet", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
 2. `Agent(subagent_type: "pr-review-toolkit:silent-failure-hunter", model: "sonnet", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
 3. `Agent(subagent_type: "pr-review-toolkit:pr-test-analyzer", model: "sonnet", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
 4. `Agent(subagent_type: "pr-review-toolkit:comment-analyzer", model: "haiku", prompt: "<criteria path> + <copy the Tooling note block above verbatim> + <task>")`
+
+Launch ONLY the reviewers in the selector's `REVIEWERS:` set — the four above are
+templates, and `code-reviewer` is always present. Include BOTH the Tooling note and
+the Review scope discipline block (verbatim) in every reviewer prompt.
 
 Results return automatically. No shutdown procedure needed.
 
@@ -176,7 +208,9 @@ If all pass: "Security Checklist: ALL PASS (N items checked)"
 🔴 MANDATORY: If Step 4 produced ANY critical or important issues, or security failures, this step MUST execute.
 
 🔴 VIOLATION — Re-review Required After Fixes
-After fixer applies fixes, ALL 4 reviewers MUST be re-invoked (same parallel pattern as Step 2).
+After fixer applies fixes, ALL reviewers in Step 2's selected set MUST be re-invoked
+(same parallel pattern as Step 2; `code-reviewer` is always in that set, preserving
+independent verification).
 Skipping re-review is a workflow violation.
 
 ```
@@ -192,8 +226,9 @@ FOR iteration = 1 TO MAX_ITERATIONS:
   2. Fixer applies fixes and runs tests
      IF tests fail after 2 retries → report to user, do NOT merge, BREAK
 
-  3. Re-review: Launch ALL 4 reviewers again (parallel Agent tool calls, same as Step 2,
-     including the tooling note in each subagent prompt)
+  3. Re-review: Launch the SAME selected reviewer set again (parallel Agent tool calls,
+     same as Step 2, including BOTH the Tooling note and the Review scope discipline
+     block in each subagent prompt)
 
   4. Collect fresh counts: fresh_critical, fresh_important, fresh_security
 

--- a/plugins/code/skills/pr-review-team/SKILL.md
+++ b/plugins/code/skills/pr-review-team/SKILL.md
@@ -26,7 +26,7 @@ restart the loop rather than paper over it. Run init now.
 
 The leader MUST:
 1. Initialize state and gather PR context (Step 1)
-2. Launch 4 parallel reviewer subagents (Step 2)
+2. Select and launch the parallel reviewer subagents (Step 2 — the selector decides which of the 4 run)
 3. Run CI checks via script (Step 3)
 4. Integrate results + security checklist (Step 4)
 5. If critical > 0 OR important > 0 OR security != "all_pass": enter fix loop (Step 5)
@@ -127,6 +127,10 @@ Review criteria: include `${CLAUDE_PLUGIN_ROOT}/references/review-criteria.md` p
 | pr-test-analyzer | WARNING | Continue with remaining reviewers. Note in report. |
 | comment-analyzer | WARNING | Continue with remaining reviewers. Note in report. |
 
+This table applies ONLY to reviewers the selector chose to launch. A reviewer the
+selector **skipped** (its `DECISION: SKIP` line) is NOT a launch failure — track it
+separately and report it as "skipped by selector (reason)", never as "failed to launch".
+
 ### Update State
 
 ```bash
@@ -208,9 +212,11 @@ If all pass: "Security Checklist: ALL PASS (N items checked)"
 🔴 MANDATORY: If Step 4 produced ANY critical or important issues, or security failures, this step MUST execute.
 
 🔴 VIOLATION — Re-review Required After Fixes
-After fixer applies fixes, ALL reviewers in Step 2's selected set MUST be re-invoked
-(same parallel pattern as Step 2; `code-reviewer` is always in that set, preserving
-independent verification).
+After fixer applies fixes, RE-RUN `select-reviewers.sh <PR番号>` and re-invoke ALL
+reviewers in the freshly-computed set (same parallel pattern as Step 2). Re-running
+the selector is mandatory because the fixer may have added files of a type the initial
+selection skipped (e.g. a docs-only PR whose fix introduces a code or test file) — the
+set can only grow, never lose `code-reviewer`, so independent verification is preserved.
 Skipping re-review is a workflow violation.
 
 ```
@@ -226,9 +232,10 @@ FOR iteration = 1 TO MAX_ITERATIONS:
   2. Fixer applies fixes and runs tests
      IF tests fail after 2 retries → report to user, do NOT merge, BREAK
 
-  3. Re-review: Launch the SAME selected reviewer set again (parallel Agent tool calls,
-     same as Step 2, including BOTH the Tooling note and the Review scope discipline
-     block in each subagent prompt)
+  3. Re-review: RE-RUN `select-reviewers.sh <PR番号>` and launch its freshly-computed
+     reviewer set (parallel Agent tool calls, same as Step 2, including BOTH the Tooling
+     note and the Review scope discipline block in each subagent prompt). The set can
+     only grow if the fixer added files of a previously-skipped type.
 
   4. Collect fresh counts: fresh_critical, fresh_important, fresh_security
 
@@ -276,7 +283,8 @@ Report summary:
 - Iterations performed
 - Security checklist status
 - CI status (including any PENDING timeouts)
-- Agents that failed to launch (if any)
+- Reviewers skipped by the selector, with reason (NOT failures — e.g. "pr-test-analyzer: skipped, no source-code files")
+- Agents that failed to launch (if any) — distinct from the skipped list above
 
 **Do NOT merge** — wait for user's explicit instruction.
 


### PR DESCRIPTION
## 概要

`/code:pr-review-team` のトークン消費を削減（施策1・3）。Closes #273。

## 実測（直近300セッション中10件）

| 指標 | 値 |
|---|---|
| reviewer 起動数/セッション | min 2 / median 9 / max 41 / mean 13.3 |
| 反復回数分布 | 1回×4, 2回×1, 3回×2, 4回×2, 10回×1（0 iteration 収束は皆無） |

最大コスト源 = fix 後の 4 体フル再起動 ＋ reviewer の diff 外探索。

## 変更

- **`select-reviewers.sh`（新規）**: 変更ファイル種別で reviewer を決定論的に選択。
  - code-reviewer 常時 / silent-failure-hunter・pr-test-analyzer はコード変更時 / comment-analyzer はコード・doc 変更時 / fail-open。
  - 検証: docs-only→2体, config-only→1体, code→4体, 拡張子なし→4体。
- **SKILL.md**: reviewer/re-reviewer prompt に scope 規律（diff 外探索禁止＋compact 出力）を必須挿入。Step2/Step5 を選択セット起動に配線。
- **command doc**: 条件起動に更新、誤記「最大5回」→「最大3回」是正。

## 保証の維持

- code-reviewer は常に選択セット内 → 独立検証・Issue #245 の自己判定禁止を保持。
- `MAX_ITERATIONS=3` 据え置き（実測上、削っても典型コストは減らず安全網のみ喪失）。

## 後続

施策2（fixer が触れた箇所・指摘観点だけの部分再レビュー）は別 PR で予定。

## 有効化

このリポジトリは GitHub ソースのマーケットプレイスのため、マージ後 `/plugin update` → `/reload-plugins` で反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)