### PR TITLE
chore: ignore nested .claude/plans scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Claude Code
 .claude/review-approved
 .claude/plans/
+**/.claude/plans/
 .claude/.context-budget.json
 .claude/dev-cycle-checkpoint.md
 .claude/dev-cycle.state.json


### PR DESCRIPTION
## 概要

プラン生成ツールが `plugins/.claude/plans/` 等の**ネスト位置**に出力する scratch ファイル（`graceful-baking-duckling.md` 等）が未追跡として残っていた。

既存の `.gitignore` は `.claude/plans/`（ルート限定アンカー）のみ無視しており、ネストした `.claude/plans/` を拾わない。`**/.claude/plans/` を1行追加して解消。

## 変更

- `.gitignore`: `**/.claude/plans/` を追加（既存ファイルはディスク上に残存、追跡対象から外れるのみ）。

## 補足

`docs/plans/` 配下（例: `twinkling-launching-thompson.md`）は正当な設計メモのため対象外（この無視ルールの影響を受けない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)