### PR TITLE
feat(cvi): clarify main/sub channel relationship in rule injection

### DIFF
--- a/plugins/cvi/scripts/enforce-cvi-rules.sh
+++ b/plugins/cvi/scripts/enforce-cvi-rules.sh
@@ -55,7 +55,7 @@ ABSOLUTELY REQUIRED (NO EXCEPTIONS):
 1. /cvi:speak: MUST call using Skill tool (NOT as text)
 2. Summary language: ${VOICE_LANG} (${VOICE_LANG_DISPLAY})
 3. Response language: MUST use ${RESPONSE_LANG}
-4. ${RESPONSE_LANG} body = MAIN channel (full substance). ${VOICE_LANG_DISPLAY} voice summary = SUB (summary only). NEVER end a response with only the Voice line.
+4. ${RESPONSE_LANG} body = MAIN channel (must carry the full substance). ${VOICE_LANG_DISPLAY} voice summary = SUB (summary only, never a substitute for the body).
 
 🔴 MANDATORY TASK COMPLETION PATTERN:
    [detailed work...]
@@ -96,7 +96,7 @@ BEFORE RESPONDING, VERIFY:
 □ /cvi:speak called via Skill tool (NOT as text)
 □ Summary language = ${VOICE_LANG} (${VOICE_LANG_DISPLAY})
 □ Response language = ${RESPONSE_LANG}
-□ Response ends with ${RESPONSE_LANG} body text (NOT the Voice line)
+□ ${RESPONSE_LANG} body text carries the full substance (Voice line is a summary, not a substitute)
 
 ⚠️ IF YOU FORGET /cvi:speak:
 → Stop hook will BLOCK your stop request

--- a/plugins/cvi/scripts/enforce-cvi-rules.sh
+++ b/plugins/cvi/scripts/enforce-cvi-rules.sh
@@ -55,6 +55,7 @@ ABSOLUTELY REQUIRED (NO EXCEPTIONS):
 1. /cvi:speak: MUST call using Skill tool (NOT as text)
 2. Summary language: ${VOICE_LANG} (${VOICE_LANG_DISPLAY})
 3. Response language: MUST use ${RESPONSE_LANG}
+4. ${RESPONSE_LANG} body = MAIN channel (full substance). ${VOICE_LANG_DISPLAY} voice summary = SUB (summary only). NEVER end a response with only the Voice line.
 
 🔴 MANDATORY TASK COMPLETION PATTERN:
    [detailed work...]
@@ -95,6 +96,7 @@ BEFORE RESPONDING, VERIFY:
 □ /cvi:speak called via Skill tool (NOT as text)
 □ Summary language = ${VOICE_LANG} (${VOICE_LANG_DISPLAY})
 □ Response language = ${RESPONSE_LANG}
+□ Response ends with ${RESPONSE_LANG} body text (NOT the Voice line)
 
 ⚠️ IF YOU FORGET /cvi:speak:
 → Stop hook will BLOCK your stop request


### PR DESCRIPTION
## 概要

日本語本文と英語音声要約の主従関係を CVI hook 注入文（`enforce-cvi-rules.sh`）に明記する。

## 背景

現状「本文がメイン・音声はサブ」という意図がルール注入文に書かれておらず、実運用でモデルが本文を薄くして音声要約側に実質を載せ、Voice 行だけで応答が終わってしまう問題が起きた（2026-07-18・orbitscore セッションで実例）。

## 変更内容

- TOP SLICE: 「本文がメインチャネル（実質を全て含む）、音声要約はサブ（サマリーのみ）。Voice 行だけで応答を終えるのは禁止」を追加
- BOTTOM SLICE: 「応答が本文で終わっているか（Voice 行ではなく）」のチェック項目を追加

owner 固有表現（listening practice）は含めず一般化した表現を使用。既存の `${RESPONSE_LANG}` / `${VOICE_LANG_DISPLAY}` 変数化を維持し、追記は計3行以内に抑えた（毎プロンプト注入のトークンコストを考慮）。

## 検証

- `bash -n` で構文確認
- `CVI_ENABLED=on` で新規2行が出力されることを確認
- 隔離 `HOME` 環境で `CVI_ENABLED=off` の早期 exit（0行出力）が変更後も保たれていることを確認（実ユーザー設定には触れず検証）

Closes #280

## Subtree 反映について

cvi は subtree 管理プラグイン。マージ後、`git subtree push --prefix=plugins/cvi https://github.com/signalcompose/cvi.git main` で upstream に反映が必要。